### PR TITLE
CoreDNS integration - use docker host's domain names resolving capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,17 @@ COPY src/ /app/
 WORKDIR /app
 RUN npm ci --production
 
+FROM golang:1.17 AS build-coredns
+
+# download latest CoreDNS sources and compile them into binary /source/coredns
+RUN mkdir /source && \
+  COREDNS_VERSION=$(curl -sX GET "https://api.github.com/repos/coredns/coredns/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]' | awk '{print substr($1,2); }') && \
+  curl --location https://github.com/coredns/coredns/archive/refs/tags/v${COREDNS_VERSION}.tar.gz \
+    | tar xz --directory /source --strip-components 1 && \
+  cd /source && \
+  make
+
 # Copy build result to a new image.
 # This saves a lot of disk space.
 FROM docker.io/library/node:14-alpine@sha256:dc92f36e7cd917816fa2df041d4e9081453366381a00f40398d99e9392e78664
@@ -36,22 +47,10 @@ RUN npm i -g nodemon
 # Install Linux packages
 RUN apk add -U --no-cache \
   wireguard-tools \
-  dumb-init \
-  curl
+  dumb-init
 
-# Install latest coredns
-RUN mkdir /coredns && \
-  COREDNS_VERSION=$(curl -sX GET "https://api.github.com/repos/coredns/coredns/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]' | awk '{print substr($1,2); }') && \
-  curl -o \
-	  /tmp/coredns.tar.gz -L \
-	  "https://github.com/coredns/coredns/releases/download/v${COREDNS_VERSION}/coredns_${COREDNS_VERSION}_linux_amd64.tgz" && \
-  tar xf \
-	  /tmp/coredns.tar.gz -C \
-	  /coredns && \
-  rm -rf /tmp/coredns.tar.gz
-
-COPY coredns/Corefile /coredns
+COPY --from=build-coredns /source/coredns /coredns/
+COPY coredns/Corefile /coredns/
 COPY entrypoint.sh /
 
 # Expose Ports

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,8 @@ EXPOSE 51821/tcp
 # Set Environment
 ENV DEBUG=Server,WireGuard
 
-# Run Web UI
-WORKDIR /
+# Set workdir to /app for eg 'docker exec' commands
+WORKDIR /app
 
 # Run Web UI and CoreDNS
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,7 @@ ENV DEBUG=Server,WireGuard
 
 # Run Web UI
 WORKDIR /
-CMD ["./entrypoint.sh"]
+
+# Run Web UI and CoreDNS
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ These options can be configured by setting environment variables using `-e KEY="
 | `WG_MTU` | `null` | `1420` | The MTU the clients will use. Server uses default WG MTU. |
 | `WG_PERSISTENT_KEEPALIVE` | `0` | `25` | Value in seconds to keep the "connection" open. If this value is 0, then connections won't be kept alive. |
 | `WG_DEFAULT_ADDRESS` | `10.8.0.x` | `10.6.0.x` | Clients IP address range. |
-| `WG_DEFAULT_DNS` | `1.1.1.1` | `8.8.8.8, 8.8.4.4` | DNS server clients will use. |
+| `WG_DEFAULT_DNS` | `1.1.1.1` | `8.8.8.8, 8.8.4.4`, `auto` | DNS server clients will use. Keyword 'auto' means resolve domain names using docker host. |
 | `WG_ALLOWED_IPS` | `0.0.0.0/0, ::/0` | `192.168.15.0/24, 10.0.1.0/24` | Allowed IPs clients will use. |
 | `WG_PRE_UP` | `...` | - | See [config.js](https://github.com/WeeJeWel/wg-easy/blob/master/src/config.js#L19) for the default value. |
 | `WG_POST_UP` | `...` | `iptables ...` | See [config.js](https://github.com/WeeJeWel/wg-easy/blob/master/src/config.js#L20) for the default value. |

--- a/coredns/Corefile
+++ b/coredns/Corefile
@@ -1,0 +1,4 @@
+. {
+    loop
+    forward . /etc/resolv.conf
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+# run coredns on background
+cd /coredns && ./coredns &
+
+# run node
+cd /app && exec /usr/bin/dumb-init node server.js

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# run coredns on background
+# run CoreDNS in background
+echo "Running CoreDNS in background"
 cd /coredns && ./coredns &
 
-# run node
+# run app using node
+echo "Running app"
 cd /app && exec node server.js

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
+#!/bin/bash
+
 # run coredns on background
 cd /coredns && ./coredns &
 
 # run node
-cd /app && exec /usr/bin/dumb-init node server.js
+cd /app && exec node server.js

--- a/src/config.js
+++ b/src/config.js
@@ -11,9 +11,17 @@ module.exports.WG_PORT = process.env.WG_PORT || 51820;
 module.exports.WG_MTU = process.env.WG_MTU || null;
 module.exports.WG_PERSISTENT_KEEPALIVE = process.env.WG_PERSISTENT_KEEPALIVE || 0;
 module.exports.WG_DEFAULT_ADDRESS = process.env.WG_DEFAULT_ADDRESS || '10.8.0.x';
-module.exports.WG_DEFAULT_DNS = typeof process.env.WG_DEFAULT_DNS === 'string'
-  ? process.env.WG_DEFAULT_DNS
-  : '1.1.1.1';
+module.exports.WG_DEFAULT_DNS = serverIp => {
+    if (typeof process.env.WG_DEFAULT_DNS === 'string') {
+        if (process.env.WG_DEFAULT_DNS === 'auto') {
+            return serverIp;
+        }
+
+        return process.env.WG_DEFAULT_DNS;
+    }
+
+    return '1.1.1.1';
+};
 module.exports.WG_ALLOWED_IPS = process.env.WG_ALLOWED_IPS || '0.0.0.0/0, ::/0';
 
 module.exports.WG_PRE_UP = process.env.WG_PRE_UP || '';

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -195,12 +195,13 @@ AllowedIPs = ${client.address}/32`;
   async getClientConfiguration({ clientId }) {
     const config = await this.getConfig();
     const client = await this.getClient({ clientId });
+    const dns = WG_DEFAULT_DNS(config.server.address);
 
     return `
 [Interface]
 PrivateKey = ${client.privateKey}
 Address = ${client.address}/24
-${WG_DEFAULT_DNS ? `DNS = ${WG_DEFAULT_DNS}` : ''}
+${dns ? `DNS = ${dns}` : ''}
 ${WG_MTU ? `MTU = ${WG_MTU}` : ''}
 
 [Peer]


### PR DESCRIPTION
Hi,

I have seen this functionality in https://github.com/linuxserver/docker-wireguard#parameters project and found it super useful. **It forwards domain names resolving to the docker host.**

This comes really handy if you run your own DNS server (eg. `pi-hole`) and you do not want to hard-code it's IP into container config. Or your server itself has some complex domain names resolving scheme and you want clients to use it.

I would set it as default (as is in the source project) but that would be breaking change (your default is `1.1.1.1`).

The little downside is added size of 46MB.
```
$ docker images | grep wg
wg-easy                               latest         e35491bbd4a7   5 minutes ago    188MB
weejewel/wg-easy                      latest         c90b263d8a38   3 weeks ago      142MB
```

The CoreDNS installation always uses the latest version. This could be changed for more stable releases of `wg-easy`.
CoreDNS is also available in docker image format. This could ease the install using multistage build. However only `x86` architecture is dockerized, so the installation for `arm` architecture would have to be done downloading it from internet using `curl`. The source project [use](https://github.com/linuxserver/docker-wireguard/blob/master/Dockerfile#L51) `curl` download for both platforms making it much more easier to manage. I have reused the same code.

It is also possible to export the port 53 and allow anyone on the network to use the server's domain names resolving capabilities.