### PR TITLE
Add boringtun support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,16 @@ RUN apk add -U --no-cache \
   wireguard-tools \
   dumb-init
 
+COPY boringtun-cli /usr/local/sbin/boringtun
+
 # Expose Ports
 EXPOSE 51820/udp
 EXPOSE 51821/tcp
 
 # Set Environment
 ENV DEBUG=Server,WireGuard
+ENV WG_QUICK_USERSPACE_IMPLEMENTATION=boringtun
+ENV WG_SUDO=1
 
 # Run Web UI
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ EXPOSE 51821/tcp
 ENV DEBUG=Server,WireGuard
 
 # Environment for using boringtun
-# ENV WG_QUICK_USERSPACE_IMPLEMENTATION
+# ENV WG_QUICK_USERSPACE_IMPLEMENTATION=boringtun
 ENV WG_SUDO=1
 
 # Run Web UI

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apk add -U --no-cache \
   wireguard-tools \
   dumb-init
 
-COPY boringtun-cli /usr/local/sbin/boringtun
+COPY --from=leonnicolas/boringtun:alpine /boringtun-cli /usr/local/sbin/boringtun
 
 # Expose Ports
 EXPOSE 51820/udp
@@ -46,7 +46,9 @@ EXPOSE 51821/tcp
 
 # Set Environment
 ENV DEBUG=Server,WireGuard
-ENV WG_QUICK_USERSPACE_IMPLEMENTATION=boringtun
+
+# Environment for using boringtun
+# ENV WG_QUICK_USERSPACE_IMPLEMENTATION
 ENV WG_SUDO=1
 
 # Run Web UI

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@
 # #
 # #
 
+# Build boringtun
+FROM rust:1.62.1 AS boringtun-builder
+RUN rustup target add x86_64-unknown-linux-musl
+RUN apt-get update && apt-get install -y musl-tools && \
+  cargo install boringtun-cli --target x86_64-unknown-linux-musl
+
 FROM docker.io/library/node:14-alpine@sha256:dc92f36e7cd917816fa2df041d4e9081453366381a00f40398d99e9392e78664 AS build_node_modules
 
 # Copy Web UI
@@ -38,7 +44,8 @@ RUN apk add -U --no-cache \
   wireguard-tools \
   dumb-init
 
-COPY --from=leonnicolas/boringtun:alpine /boringtun-cli /usr/local/sbin/boringtun
+# Copy boringtun
+COPY --from=boringtun-builder /usr/local/cargo/bin/boringtun-cli /usr/local/sbin/boringtun
 
 # Expose Ports
 EXPOSE 51820/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 51821/tcp
 ENV DEBUG=Server,WireGuard
 
 # Environment for using boringtun
-# ENV WG_QUICK_USERSPACE_IMPLEMENTATION=boringtun
+ENV WG_QUICK_USERSPACE_IMPLEMENTATION=boringtun
 ENV WG_SUDO=1
 
 # Run Web UI

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ This image has builtin [boringtun](https://github.com/cloudflare/boringtun) supp
 [boringtun](https://github.com/cloudflare/boringtun) is a userspace wireguard implementation using Rust. It is similar to [wireguard-go](https://git.zx2c4.com/wireguard-go) with a smaller memory footprint.
 The TUN device `/dev/net/tun` needs to exist on the host for `boringtun` to work.
 
-To activate `boringtun` in wg-easy, you need to set the `WG_QUICK_USERSPACE_IMPLEMENTATION` environment variable and mount the `/dev/net/tun` device when running the container.
+To activate `boringtun` in wg-easy, you need to mount the `/dev/net/tun` device when running the container.
+The `wg-quick` will automatically fallback to userspace implementation if the kernel module doesn't exist.
 
 <pre>
 $ docker run -d \
@@ -93,11 +94,8 @@ $ docker run -d \
   --sysctl="net.ipv4.conf.all.src_valid_mark=1" \
   --sysctl="net.ipv4.ip_forward=1" \
   --restart unless-stopped \
-  -e WG_QUICK_USERSPACE_IMPLEMENTATION=boringtun
   weejewel/wg-easy
 </pre>
-
-Big thanks to leonnicolas for his [boringtun docker image](https://github.com/leonnicolas/boringtun).
 
 ### 3. Sponsor
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ $ docker run -d \
   -e WG_HOST=<b>🚨YOUR_SERVER_IP</b> \
   -e PASSWORD=<b>🚨YOUR_ADMIN_PASSWORD</b> \
   -v ~/.wg-easy:/etc/wireguard \
-  -device /dev/net/tun:/dev/net/tun \
   -p 51820:51820/udp \
   -p 51821:51821/tcp \
   --cap-add=NET_ADMIN \
@@ -71,6 +70,34 @@ $ docker run -d \
 The Web UI will now be available on `http://0.0.0.0:51821`.
 
 > 💡 Your configuration files will be saved in `~/.wg-easy`
+
+#### 2.1 Using boringtun
+
+This image has builtin [boringtun](https://github.com/cloudflare/boringtun) support for machines with older kernel or limited virtual environments such as OpenVZ.
+[boringtun](https://github.com/cloudflare/boringtun) is a userspace wireguard implementation using Rust. It is similar to [wireguard-go](https://git.zx2c4.com/wireguard-go) with a smaller memory footprint.
+The TUN device `/dev/net/tun` needs to exist on the host for `boringtun` to work.
+
+To activate `boringtun` in wg-easy, you need to set the `WG_QUICK_USERSPACE_IMPLEMENTATION` environment variable and mount the `/dev/net/tun` device when running the container.
+
+<pre>
+$ docker run -d \
+  --name=wg-easy \
+  -e WG_HOST=<b>🚨YOUR_SERVER_IP</b> \
+  -e PASSWORD=<b>🚨YOUR_ADMIN_PASSWORD</b> \
+  -v ~/.wg-easy:/etc/wireguard \
+  -device /dev/net/tun:/dev/net/tun \
+  -p 51820:51820/udp \
+  -p 51821:51821/tcp \
+  --cap-add=NET_ADMIN \
+  --cap-add=SYS_MODULE \
+  --sysctl="net.ipv4.conf.all.src_valid_mark=1" \
+  --sysctl="net.ipv4.ip_forward=1" \
+  --restart unless-stopped \
+  -e WG_QUICK_USERSPACE_IMPLEMENTATION=boringtun
+  weejewel/wg-easy
+</pre>
+
+Big thanks to leonnicolas for his [boringtun docker image](https://github.com/leonnicolas/boringtun).
 
 ### 3. Sponsor
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $ docker run -d \
   -e WG_HOST=<b>🚨YOUR_SERVER_IP</b> \
   -e PASSWORD=<b>🚨YOUR_ADMIN_PASSWORD</b> \
   -v ~/.wg-easy:/etc/wireguard \
+  -device /dev/net/tun:/dev/net/tun \
   -p 51820:51820/udp \
   -p 51821:51821/tcp \
   --cap-add=NET_ADMIN \


### PR DESCRIPTION
* Add builtin boringtun binary from leonnicolas/boringtun:alpine.
* Activate boringtun by setting environment variable and mounting device. Description has added to the README.md

It might be nicer to build the boringtun support into a seperated tag to avoid the 3MB if not used.