### PR TITLE
Import json configurations with no PreShared-Key

### DIFF
--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -110,8 +110,8 @@ PostDown = ${WG_POST_DOWN}
 # Client: ${client.name} (${clientId})
 [Peer]
 PublicKey = ${client.publicKey}
-PresharedKey = ${client.preSharedKey}
-AllowedIPs = ${client.address}/32`;
+${client.preSharedKey ? `PresharedKey = ${client.preSharedKey}\n` : ''
+}AllowedIPs = ${client.address}/32`;
     }
 
     debug('Config saving...');
@@ -205,8 +205,8 @@ ${WG_MTU ? `MTU = ${WG_MTU}` : ''}
 
 [Peer]
 PublicKey = ${config.server.publicKey}
-PresharedKey = ${client.preSharedKey}
-AllowedIPs = ${WG_ALLOWED_IPS}
+${client.preSharedKey ? `PresharedKey = ${client.preSharedKey}\n` : ''
+}AllowedIPs = ${WG_ALLOWED_IPS}
 PersistentKeepalive = ${WG_PERSISTENT_KEEPALIVE}
 Endpoint = ${WG_HOST}:${WG_PORT}`;
   }


### PR DESCRIPTION
Hi. When migrating old setups, one may want to keep existing clients, so you don't have to roll out all new configs.

In our case our clients do not yet have a PSK, but if we remove them from the config, wg-easy won't accept it and die.

This patch just changes the config-generation so that missing PSKs will just be ignored. The UI and the generation of new users is not touched, so this only affects configs, where you manually remove the PSK from the wg0.json.