### PR TITLE
Allow running this software as unprivilidged software

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,8 @@
 
 const { release } = require('./package.json');
 
+module.exports.USE_SUDO = process.env.USE_SUDO || (process.getuid() !== 0);
+module.exports.SUDO_STRING = module.exports.USE_SUDO ? 'sudo ' : '';
 module.exports.RELEASE = release;
 module.exports.PORT = process.env.PORT || 51821;
 module.exports.PASSWORD = process.env.PASSWORD;
@@ -18,10 +20,10 @@ module.exports.WG_ALLOWED_IPS = process.env.WG_ALLOWED_IPS || '0.0.0.0/0, ::/0';
 
 module.exports.WG_PRE_UP = process.env.WG_PRE_UP || '';
 module.exports.WG_POST_UP = process.env.WG_POST_UP || `
-iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o eth0 -j MASQUERADE;
-iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT;
-iptables -A FORWARD -i wg0 -j ACCEPT;
-iptables -A FORWARD -o wg0 -j ACCEPT;
+${module.exports.SUDO_STRING}iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o eth0 -j MASQUERADE;
+${module.exports.SUDO_STRING}iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT;
+${module.exports.SUDO_STRING}iptables -A FORWARD -i wg0 -j ACCEPT;
+${module.exports.SUDO_STRING}iptables -A FORWARD -o wg0 -j ACCEPT;
 `.split('\n').join(' ');
 
 module.exports.WG_PRE_DOWN = process.env.WG_PRE_DOWN || '';

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@
 const { release } = require('./package.json');
 
 module.exports.USE_SUDO = process.env.USE_SUDO || (process.getuid() !== 0);
-module.exports.SUDO_STRING = module.exports.USE_SUDO ? 'sudo ' : '';
+module.exports.SUDO_STRING = module.exports.USE_SUDO ? 'sudo -n ' : '';
 module.exports.RELEASE = release;
 module.exports.PORT = process.env.PORT || 51821;
 module.exports.PASSWORD = process.env.PASSWORD;

--- a/src/config.js
+++ b/src/config.js
@@ -20,10 +20,10 @@ module.exports.WG_ALLOWED_IPS = process.env.WG_ALLOWED_IPS || '0.0.0.0/0, ::/0';
 
 module.exports.WG_PRE_UP = process.env.WG_PRE_UP || '';
 module.exports.WG_POST_UP = process.env.WG_POST_UP || `
-${module.exports.SUDO_STRING}iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o eth0 -j MASQUERADE;
-${module.exports.SUDO_STRING}iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT;
-${module.exports.SUDO_STRING}iptables -A FORWARD -i wg0 -j ACCEPT;
-${module.exports.SUDO_STRING}iptables -A FORWARD -o wg0 -j ACCEPT;
+iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o eth0 -j MASQUERADE;
+iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT;
+iptables -A FORWARD -i wg0 -j ACCEPT;
+iptables -A FORWARD -o wg0 -j ACCEPT;
 `.split('\n').join(' ');
 
 module.exports.WG_PRE_DOWN = process.env.WG_PRE_DOWN || '';

--- a/src/lib/Util.js
+++ b/src/lib/Util.js
@@ -2,6 +2,8 @@
 
 const childProcess = require('child_process');
 
+const shellSymbol = (process.getuid() === 0) ? '#' : '$';
+
 module.exports = class Util {
 
   static isValidIPv4(str) {
@@ -57,10 +59,10 @@ module.exports = class Util {
   } = {}) {
     if (typeof log === 'string') {
       // eslint-disable-next-line no-console
-      console.log(`$ ${log}`);
+      console.log(`${shellSymbol} ${log}`);
     } else if (log === true) {
       // eslint-disable-next-line no-console
-      console.log(`$ ${cmd}`);
+      console.log(`${shellSymbol} ${cmd}`);
     }
 
     if (process.platform !== 'linux') {

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -127,9 +127,7 @@ AllowedIPs = ${client.address}/32`;
 
   async __syncConfig() {
     debug('Config syncing...');
-    await Util.exec(`${SUDO_STRING} bash -c "wg syncconf wg0 <(wg-quick strip wg0)"`, {
-      log: `${SUDO_STRING}wg syncconf wg0 <(${SUDO_STRING}wg-quick strip wg0)`,
-    });
+    await Util.exec(`${SUDO_STRING}wg-quick strip wg0 | ${SUDO_STRING}wg syncconf wg0 /dev/fd/0`);
     debug('Config synced.');
   }
 

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -11,7 +11,7 @@ const Util = require('./Util');
 const ServerError = require('./ServerError');
 
 const {
-  WG_SUDO_STRING,
+  SUDO_STRING,
   WG_PATH,
   WG_HOST,
   WG_PORT,
@@ -42,9 +42,9 @@ module.exports = class WireGuard {
           config = JSON.parse(config);
           debug('Configuration loaded.');
         } catch (err) {
-          const privateKey = await Util.exec(`${WG_SUDO_STRING}wg genkey`);
-          const publicKey = await Util.exec(`echo ${privateKey} | ${WG_SUDO_STRING}wg pubkey`, {
-            log: `echo ***hidden*** | ${WG_SUDO_STRING}wg pubkey`,
+          const privateKey = await Util.exec(`${SUDO_STRING}wg genkey`);
+          const publicKey = await Util.exec(`echo ${privateKey} | ${SUDO_STRING}wg pubkey`, {
+            log: `echo ***hidden*** | ${SUDO_STRING}wg pubkey`,
           });
           const address = WG_DEFAULT_ADDRESS.replace('x', '1');
 
@@ -60,8 +60,8 @@ module.exports = class WireGuard {
         }
 
         await this.__saveConfig(config);
-        await Util.exec(`${WG_SUDO_STRING}wg-quick down wg0`).catch(() => { });
-        await Util.exec(`${WG_SUDO_STRING}wg-quick up wg0`).catch(err => {
+        await Util.exec(`${SUDO_STRING}wg-quick down wg0`).catch(() => { });
+        await Util.exec(`${SUDO_STRING}wg-quick up wg0`).catch(err => {
           if (err && err.message && err.message.includes('Cannot find device "wg0"')) {
             throw new Error('WireGuard exited with the error: Cannot find device "wg0"\nThis usually means that your host\'s kernel does not support WireGuard!');
           }
@@ -127,7 +127,7 @@ AllowedIPs = ${client.address}/32`;
 
   async __syncConfig() {
     debug('Config syncing...');
-    await Util.exec(`${WG_SUDO_STRING}wg syncconf wg0 <(${WG_SUDO_STRING}wg-quick strip wg0)`);
+    await Util.exec(`${SUDO_STRING}wg syncconf wg0 <(${SUDO_STRING}wg-quick strip wg0)`);
     debug('Config synced.');
   }
 
@@ -150,7 +150,7 @@ AllowedIPs = ${client.address}/32`;
     }));
 
     // Loop WireGuard status
-    const dump = await Util.exec(`${WG_SUDO_STRING}wg show wg0 dump`, {
+    const dump = await Util.exec(`${SUDO_STRING}wg show wg0 dump`, {
       log: false,
     });
     dump
@@ -227,11 +227,11 @@ Endpoint = ${WG_HOST}:${WG_PORT}`;
 
     const config = await this.getConfig();
 
-    const privateKey = await Util.exec(`${WG_SUDO_STRING}wg genkey`);
-    const publicKey = await Util.exec(`echo ${privateKey} | ${WG_SUDO_STRING}wg pubkey`, {
-      log: `echo ***hidden*** | ${WG_SUDO_STRING}wg pubkey`,
+    const privateKey = await Util.exec(`${SUDO_STRING}wg genkey`);
+    const publicKey = await Util.exec(`echo ${privateKey} | ${SUDO_STRING}wg pubkey`, {
+      log: `echo ***hidden*** | ${SUDO_STRING}wg pubkey`,
     });
-    const preSharedKey = await Util.exec(`${WG_SUDO_STRING}wg genpsk`);
+    const preSharedKey = await Util.exec(`${SUDO_STRING}wg genpsk`);
 
     // Calculate next IP
     let address;

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -127,7 +127,9 @@ AllowedIPs = ${client.address}/32`;
 
   async __syncConfig() {
     debug('Config syncing...');
-    await Util.exec(`${SUDO_STRING}wg syncconf wg0 <(${SUDO_STRING}wg-quick strip wg0)`);
+    await Util.exec(`${SUDO_STRING} bash -c "wg syncconf wg0 <(wg-quick strip wg0)"`, {
+      log: `${SUDO_STRING}wg syncconf wg0 <(${SUDO_STRING}wg-quick strip wg0)`,
+    });
     debug('Config synced.');
   }
 


### PR DESCRIPTION
This allows running the software as an unpriviledged user.  
All that user needs to be allowed to run these commands without password:
- `wg`
- `wg-quick`

This can be achieved by putting this in the sudoers config:

```sudo
<user>       ALL=(root)      NOPASSWD: /usr/bin/wg , /usr/bin/wg-quick
```