### PR TITLE
Add PASSWORD_FILE environmental variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ These options can be configured by setting environment variables using `-e KEY="
 | Env | Default | Example | Description |
 | - | - | - | - |
 | `PASSWORD` | - | `foobar123` | When set, requires a password when logging in to the Web UI. |
+| `PASSWORD_FILE` | - | `/run/secrets/password` | Path to a mounted password file. When set, contents of the file will override value from `PASSWORD`. |
 | `WG_HOST` | - | `vpn.myserver.com` | The public hostname of your VPN server. |
 | `WG_PORT` | `51820` | `12345` | The public UDP port of your VPN server. WireGuard will always listen on `51820` inside the Docker container. |
 | `WG_MTU` | `null` | `1420` | The MTU the clients will use. Server uses default WG MTU. |

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,22 @@
 'use strict';
 
-const { release } = require('./package.json');
+const {release} = require('./package.json');
+const fs = require('fs');
 
 module.exports.RELEASE = release;
 module.exports.PORT = process.env.PORT || 51821;
 module.exports.PASSWORD = process.env.PASSWORD;
+// Replace the existing password if a PASSWORD_FILE env variable is present
+// if not, then print the error and proceed
+if ('PASSWORD_FILE' in process.env && fs.existsSync(process.env.PASSWORD_FILE)) {
+  try {
+    module.exports.PASSWORD = fs.readFileSync(process.env.PASSWORD_FILE, 'utf8');
+  } catch (err) {
+    console.error('Could not load the PASSWORD_FILE, using the contents of the PASSWORD variable instead');
+  }
+} else if ('PASSWORD_FILE' in process.env && !fs.existsSync(process.env.PASSWORD_FILE)) {
+  console.error('The declared PASSWORD_FILE does not exist, using the contents of the PASSWORD variable instead')
+}
 module.exports.WG_PATH = process.env.WG_PATH || '/etc/wireguard/';
 module.exports.WG_HOST = process.env.WG_HOST;
 module.exports.WG_PORT = process.env.WG_PORT || 51820;

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ module.exports.PASSWORD = process.env.PASSWORD;
 // if not, then print the error and proceed
 if ('PASSWORD_FILE' in process.env && fs.existsSync(process.env.PASSWORD_FILE)) {
   try {
-    module.exports.PASSWORD = fs.readFileSync(process.env.PASSWORD_FILE, 'utf8');
+    module.exports.PASSWORD = fs.readFileSync(process.env.PASSWORD_FILE, 'utf8').replace(/[\n\r]/g, '');
   } catch (err) {
     console.error('Could not load the PASSWORD_FILE, using the contents of the PASSWORD variable instead');
   }

--- a/src/lib/Server.js
+++ b/src/lib/Server.js
@@ -36,7 +36,7 @@ module.exports = class Server {
 
       // Authentication
       .get('/api/session', Util.promisify(async req => {
-        const requiresPassword = !!process.env.PASSWORD;
+        const requiresPassword = PASSWORD !== undefined;
         const authenticated = requiresPassword
           ? !!(req.session && req.session.authenticated)
           : true;


### PR DESCRIPTION
When a PASSWORD_FILE environmental variable is provided read the PASSWORD from it instead of using the PASSWORD environmental variable directly.

Closes #401.