### PR TITLE
Fix small screen layout

### DIFF
--- a/src/www/index.html
+++ b/src/www/index.html
@@ -121,7 +121,7 @@
                 </div>
               </div>
 
-              <div class="relative p-5 z-10 flex flex-row">
+              <div class="relative p-5 z-10 flex flex-row flex-wrap justify-start">
                 <div class="h-10 w-10 mr-5 rounded-full bg-gray-50 relative">
                   <svg class="w-6 m-2 text-gray-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"
                     fill="currentColor">
@@ -137,7 +137,7 @@
                   </div>
                 </div>
 
-                <div class="flex-grow">
+                <div class="sm:flex-grow">
 
                   <!-- Name -->
                   <div class="text-gray-700 group" :title="'Created on ' + dateTime(new Date(client.createdAt))">
@@ -230,7 +230,7 @@
                   </div>
                 </div>
 
-                <div class="text-right">
+                <div class="text-right w-full sm:w-auto mt-3 sm:mt-0">
                   <div class="text-gray-400">
 
                     <!-- Enable/Disable -->

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -148,8 +148,8 @@
                       v-on:keyup.escape="clientEditName = null; clientEditNameId = null;"
                       :ref="'client-' + client.id + '-name'"
                       class="rounded px-1 border-2 border-gray-100 focus:border-gray-200 outline-none w-30" />
-                    <span v-show="clientEditNameId !== client.id"
-                      class="inline-block border-t-2 border-b-2 border-transparent">{{client.name}}</span>
+                    <span v-show="clientEditNameId !== client.id" style="max-width: 28ch;"
+                      class="inline-block border-t-2 border-b-2 border-transparent align-top sm:w-auto overflow-hidden sm:overflow-visible overflow-ellipsis">{{client.name}}</span>
 
                     <!-- Edit -->
                     <span v-show="clientEditNameId !== client.id"


### PR DESCRIPTION
Hello, this PR contains some small screen layout fixes.

<hr>

<details> 
  <summary>Before</summary>   

![1](https://user-images.githubusercontent.com/36269798/199068264-013eb671-0dd5-4919-96ba-0e0e6ce16a14.png)
</details>

<details> 
  <summary>After</summary>

![2](https://user-images.githubusercontent.com/36269798/199068701-8d2c60b6-335a-4f68-b626-e0b162eb9384.png)
</details>

Since there is no way to add a custom breakpoint, up to 640px wide client names will be displayed in clipped state with a some empty space which looks a little weird:

<details> 
  <summary><640px</summary>

![3](https://user-images.githubusercontent.com/36269798/199070076-f25b88ac-1c79-4fa7-a95c-9f01ef7f0c69.png)

</details>

Normal view above 640 pixels wide is not changed:

<details> 
  <summary>>=640px</summary>

![4](https://user-images.githubusercontent.com/36269798/199070937-5f225d67-21a8-4ada-9a0c-a9d54c476c02.png)

</details>

<hr>

Similar to #319 but also provides a fix for long client names.