### PR TITLE
allow fetching public IP instead of using defined host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # #
 # #
 
-FROM docker.io/library/node:14-alpine@sha256:dc92f36e7cd917816fa2df041d4e9081453366381a00f40398d99e9392e78664 AS build_node_modules
+FROM docker.io/library/node:18-alpine AS build_node_modules
 
 # Copy Web UI
 COPY src/ /app/
@@ -18,7 +18,7 @@ RUN npm ci --production
 
 # Copy build result to a new image.
 # This saves a lot of disk space.
-FROM docker.io/library/node:14-alpine@sha256:dc92f36e7cd917816fa2df041d4e9081453366381a00f40398d99e9392e78664
+FROM docker.io/library/node:18-alpine
 COPY --from=build_node_modules /app /app
 
 # Move node_modules one directory up, so during development

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ These options can be configured by setting environment variables using `-e KEY="
 | - | - | - | - |
 | `PASSWORD` | - | `foobar123` | When set, requires a password when logging in to the Web UI. |
 | `WG_HOST` | - | `vpn.myserver.com` | The public hostname of your VPN server. |
+| `IPIFY_URL` | - | `https://api.ipify.org?format=json` | API to fetch our public IP. |
 | `WG_PORT` | `51820` | `12345` | The public UDP port of your VPN server. WireGuard will always listen on `51820` inside the Docker container. |
 | `WG_MTU` | `null` | `1420` | The MTU the clients will use. Server uses default WG MTU. |
 | `WG_PERSISTENT_KEEPALIVE` | `0` | `25` | Value in seconds to keep the "connection" open. If this value is 0, then connections won't be kept alive. |

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ module.exports.PORT = process.env.PORT || 51821;
 module.exports.PASSWORD = process.env.PASSWORD;
 module.exports.WG_PATH = process.env.WG_PATH || '/etc/wireguard/';
 module.exports.WG_HOST = process.env.WG_HOST;
+module.exports.IPIFY_URL = process.env.IPIFY_URL;
 module.exports.WG_PORT = process.env.WG_PORT || 51820;
 module.exports.WG_MTU = process.env.WG_MTU || null;
 module.exports.WG_PERSISTENT_KEEPALIVE = process.env.WG_PERSISTENT_KEEPALIVE || 0;

--- a/src/lib/Server.js
+++ b/src/lib/Server.js
@@ -138,6 +138,16 @@ module.exports = class Server {
       .listen(PORT, () => {
         debug(`Listening on http://0.0.0.0:${PORT}`);
       });
+
+      process.on('SIGTERM', async () => {
+        debug('SIGTERM signal received: exiting')
+        Util.exec('wg-quick down wg0').then(() => {
+          debug('cleaned up wireguard');
+        });
+        this.app.close(() => {
+          debug('HTTP server closed')
+        })
+      })
   }
 
 };


### PR DESCRIPTION
Set `IPIFY_URL` instead of `WG_HOST` to automatically get the server public IP
Signed-off-by: Guillem Bonet <guillem.bonet@gmail.com>