### PR TITLE
Fix port changing

### DIFF
--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -95,7 +95,7 @@ module.exports = class WireGuard {
 [Interface]
 PrivateKey = ${config.server.privateKey}
 Address = ${config.server.address}/24
-ListenPort = 51820
+ListenPort = ${WG_PORT}
 PreUp = ${WG_PRE_UP}
 PostUp = ${WG_POST_UP}
 PreDown = ${WG_PRE_DOWN}


### PR DESCRIPTION
You forgot to apply one port parameter for config
Now this config working fine:
sudo docker run -d \
                                 --name=wg-easy \
                                 -e WG_HOST=SERV \
                                 -e PASSWORD=PASSWORD \
                                 -e WG_PORT=VPN_PORT     \
                                 -e PORT=UI_PORT \
                               -e WG_POST_UP='iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o eth0 -j MASQUERADE; iptables -A INPUT -p udp -m udp --dport !!!VPN_PORT!!! -j ACCEPT; iptables -A FORWARD -i wg0 -j ACCEPT; iptables -A FORWARD -o wg0 -j ACCEPT;' \
                                 -v ~/.wg-easy:/etc/wireguard \
                                 -p VPN_PORT:VPN_PORT/udp \
                                 -p UI_PORT:UI_PORT/tcp \
                                 --cap-add=NET_ADMIN \
                                 --cap-add=SYS_MODULE \
                                 --sysctl="net.ipv4.conf.all.src_valid_mark=1" \
                                 --sysctl="net.ipv4.ip_forward=1" \
                                 --restart unless-stopped \
                                 --expose VPN_PORT \
                                 --expose UI_PORT \
                                 weejewel/wg-easy