### PR TITLE
Changed changelog.json URL

### DIFF
--- a/src/www/js/app.js
+++ b/src/www/js/app.js
@@ -270,7 +270,7 @@ new Vue({
 
     Promise.resolve().then(async () => {
       const currentRelease = await this.api.getRelease();
-      const latestRelease = await fetch('https://weejewel.github.io/wg-easy/changelog.json')
+      const latestRelease = await fetch('https://wg-easy.github.io/wg-easy/changelog.json')
         .then(res => res.json())
         .then(releases => {
           const releasesArray = Object.entries(releases).map(([version, changelog]) => ({


### PR DESCRIPTION
It seems like this repository was transferred from github/weejewel to github/wg-easy before, but the URL of the changelog file hasn't been changed, so the wg-easy website would fail to fetch and display the newest version and throw an 404 error in the background.

![grafik](https://github.com/wg-easy/wg-easy/assets/28984823/5ca032b7-a39e-4f36-9496-5240d298e08d)

https://github.com/wg-easy/wg-easy/blob/642d6d62edb95a96e57b704966b65135f4f3ea94/src/www/js/app.js#L273

This PR changes the changelog URL to `https://wg-easy.github.io/wg-easy/changelog.json`

