### PR TITLE
Create wg-easy-npm.yml

### DIFF
--- a/wg-easy-npm.yml
+++ b/wg-easy-npm.yml
@@ -1,0 +1,32 @@
+version: "3.8"
+
+services:
+  wg-easy:
+    environment:
+      # ⚠️ Change the server's hostname (clients will connect to):
+      - WG_HOST=wg-easy.myhomelab.com
+
+      # ⚠️ Change the Web UI Password:
+      - PASSWORD=foobar123
+    image: weejewel/wg-easy
+    container_name: wg-easy
+    hostname: wg-easy
+    volumes:
+      - ~/.wg-easy:/etc/wireguard
+    ports:
+      - "51820:51820/udp"
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    sysctls:
+      - net.ipv4.ip_forward=1
+      - net.ipv4.conf.all.src_valid_mark=1
+    networks:
+      - default
+      - npm_default
+
+networks:
+  npm_default:
+    external:
+      name: npm_default


### PR DESCRIPTION
I am running portainer already with NPM as reverse proxy for websites that I am hosting. So I have modded this yml with the help of ChMaikos. You will need to put the "wg-easy" in the IP section of your NPM and use port 51821