### PR TITLE
Determine interface of default network rather than assume eth0

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const { release } = require('./package.json');
+const { execSync } = require('child_process');
 
 module.exports.RELEASE = release;
 module.exports.PORT = process.env.PORT || 51821;
 module.exports.PASSWORD = process.env.PASSWORD;
 module.exports.WG_PATH = process.env.WG_PATH || '/etc/wireguard/';
-module.exports.WG_DEVICE = process.env.WG_DEVICE || 'eth0';
+module.exports.WG_DEVICE = process.env.WG_DEVICE || execSync("ip r | grep default | cut -d ' ' -f 5 | head -n1");
 module.exports.WG_HOST = process.env.WG_HOST;
 module.exports.WG_PORT = process.env.WG_PORT || 51820;
 module.exports.WG_MTU = process.env.WG_MTU || null;


### PR DESCRIPTION
This small change defines WG_INTERFACE based on default route interface rather than assuming eth0 (handy when interface may change)