### PR TITLE
👷 use latest major version for actions/checkout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v1
         with:
           node-version: '18'


### PR DESCRIPTION
Use latest major version of [actions/checkout](https://github.com/actions/checkout) for GitHub Actions.