### PR TITLE
Revert port variable-isation *inside* container

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ These options can be configured by setting environment variables using `-e KEY="
 | `PASSWORD` | - | `foobar123` | When set, requires a password when logging in to the Web UI. |
 | `WG_HOST` | - | `vpn.myserver.com` | The public hostname of your VPN server. |
 | `WG_DEVICE` | `eth0` | `ens6f0` | Ethernet device the wireguard traffic should be forwarded through. |
-| `WG_PORT` | `51820` | `12345` | The public UDP port of your VPN server. This will also change the port wireguard will listen to. |
+| `WG_PORT` | `51820` | `12345` | The public UDP port of your VPN server. WireGuard will always listen on 51820 inside the Docker container. |
 | `WG_INTERFACE` | `wg0` | `wg1` | The interface wireguard will use in the container. (Only needed if `network_mode: host` or `--net=host` is used) |
 | `WG_MTU` | `null` | `1420` | The MTU the clients will use. Server uses default WG MTU. |
 | `WG_PERSISTENT_KEEPALIVE` | `0` | `25` | Value in seconds to keep the "connection" open. If this value is 0, then connections won't be kept alive. |

--- a/src/config.js
+++ b/src/config.js
@@ -22,7 +22,7 @@ module.exports.WG_ALLOWED_IPS = process.env.WG_ALLOWED_IPS || '0.0.0.0/0, ::/0';
 module.exports.WG_PRE_UP = process.env.WG_PRE_UP || '';
 module.exports.WG_POST_UP = process.env.WG_POST_UP || `
 iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o ${module.exports.WG_DEVICE} -j MASQUERADE;
-iptables -A INPUT -p udp -m udp --dport ${module.exports.WG_PORT} -j ACCEPT;
+iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT;
 iptables -A FORWARD -i ${module.exports.WG_INTERFACE} -j ACCEPT;
 iptables -A FORWARD -o ${module.exports.WG_INTERFACE} -j ACCEPT;
 `.split('\n').join(' ');

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -69,7 +69,7 @@ module.exports = class WireGuard {
           throw err;
         });
         // await Util.exec(`iptables -t nat -A POSTROUTING -s ${WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o ' + WG_DEVICE + ' -j MASQUERADE`);
-        // await Util.exec('iptables -A INPUT -p udp -m udp --dport ' + WG_PORT + ' -j ACCEPT');
+        // await Util.exec('iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT');
         // await Util.exec('iptables -A FORWARD -i ' + WG_INTERFACE + ' -j ACCEPT');
         // await Util.exec('iptables -A FORWARD -o ' + WG_INTERFACE + ' -j ACCEPT');
         await this.__syncConfig();
@@ -96,7 +96,7 @@ module.exports = class WireGuard {
 [Interface]
 PrivateKey = ${config.server.privateKey}
 Address = ${config.server.address}/24
-ListenPort = ${WG_PORT}
+ListenPort = 51820
 PreUp = ${WG_PRE_UP}
 PostUp = ${WG_POST_UP}
 PreDown = ${WG_PRE_DOWN}


### PR DESCRIPTION
Revert port *inside* container to 51820. Fixes https://github.com/wg-easy/wg-easy/issues/692.