### PR TITLE
config.js: auto remove the firewall rules after stop/restart

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -27,5 +27,5 @@ iptables -A FORWARD -o wg0 -j ACCEPT -m comment --comment "wg-easy rule";
 `.split('\n').join(' ');
 
 module.exports.WG_PRE_DOWN = process.env.WG_PRE_DOWN || 'iptables-save | grep -vF "wg-easy rule" | iptables-restore';
-module.exports.WG_POST_DOWN = process.env.WG_POST_DOWN || '';
+module.exports.WG_POST_DOWN = process.env.WG_POST_DOWN || 'iptables-save | grep -vF "wg-easy rule" | iptables-restore';
 module.exports.LANG = process.env.LANG || 'en';

--- a/src/config.js
+++ b/src/config.js
@@ -20,12 +20,12 @@ module.exports.WG_ALLOWED_IPS = process.env.WG_ALLOWED_IPS || '0.0.0.0/0, ::/0';
 
 module.exports.WG_PRE_UP = process.env.WG_PRE_UP || '';
 module.exports.WG_POST_UP = process.env.WG_POST_UP || `
-iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o ${module.exports.WG_DEVICE} -j MASQUERADE;
-iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT;
-iptables -A FORWARD -i wg0 -j ACCEPT;
-iptables -A FORWARD -o wg0 -j ACCEPT;
+iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o ${module.exports.WG_DEVICE} -j MASQUERADE -m comment --comment "wg-easy rule";
+iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT -m comment --comment "wg-easy rule";
+iptables -A FORWARD -i wg0 -j ACCEPT -m comment --comment "wg-easy rule";
+iptables -A FORWARD -o wg0 -j ACCEPT -m comment --comment "wg-easy rule";
 `.split('\n').join(' ');
 
-module.exports.WG_PRE_DOWN = process.env.WG_PRE_DOWN || '';
+module.exports.WG_PRE_DOWN = process.env.WG_PRE_DOWN || 'iptables-save | grep -vF "wg-easy rule" | iptables-restore';
 module.exports.WG_POST_DOWN = process.env.WG_POST_DOWN || '';
 module.exports.LANG = process.env.LANG || 'en';

--- a/src/config.js
+++ b/src/config.js
@@ -20,12 +20,12 @@ module.exports.WG_ALLOWED_IPS = process.env.WG_ALLOWED_IPS || '0.0.0.0/0, ::/0';
 
 module.exports.WG_PRE_UP = process.env.WG_PRE_UP || '';
 module.exports.WG_POST_UP = process.env.WG_POST_UP || `
-iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o ${module.exports.WG_DEVICE} -j MASQUERADE -m comment --comment "wg-easy rule";
-iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT -m comment --comment "wg-easy rule";
-iptables -A FORWARD -i wg0 -j ACCEPT -m comment --comment "wg-easy rule";
-iptables -A FORWARD -o wg0 -j ACCEPT -m comment --comment "wg-easy rule";
+iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o ${module.exports.WG_DEVICE} -j MASQUERADE;
+iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT;
+iptables -A FORWARD -i wg0 -j ACCEPT;
+iptables -A FORWARD -o wg0 -j ACCEPT;
 `.split('\n').join(' ');
 
-module.exports.WG_PRE_DOWN = process.env.WG_PRE_DOWN || 'iptables-save | grep -vF "wg-easy rule" | iptables-restore';
-module.exports.WG_POST_DOWN = process.env.WG_POST_DOWN || 'iptables-save | grep -vF "wg-easy rule" | iptables-restore';
+module.exports.WG_PRE_DOWN = process.env.WG_PRE_DOWN || '$(wg-quick down wg0)';
+module.exports.WG_POST_DOWN = process.env.WG_POST_DOWN || '$(wg-quick down wg0)';
 module.exports.LANG = process.env.LANG || 'en';


### PR DESCRIPTION
Fixes: https://github.com/wg-easy/wg-easy/issues/795
Fixes: https://github.com/wg-easy/wg-easy/issues/835
Issue duplicate firewall rules:
```
/app # iptables  -v -L -n --line-numbers | grep "51820"
7        0     0 ACCEPT     17   --  *      *       0.0.0.0/0            0.0.0.0/0            udp dpt:51820
8        0     0 ACCEPT     17   --  *      *       0.0.0.0/0            0.0.0.0/0            udp dpt:51820
6        5   880 ACCEPT     17   --  *      *       0.0.0.0/0            0.0.0.0/0            udp dpt:51820
/app # iptables -v -L -n --line-numbers | grep "51821"
7       23  1380 ACCEPT     6    --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:51821
```