### PR TITLE
Workaround CVE-2023-42282

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN mv /app/node_modules /node_modules
 # Enable this to run `npm run serve`
 RUN npm i -g nodemon
 
+# Workaround CVE-2023-42282
+RUN npm uninstall -g ip
+
 # Install Linux packages
 RUN apk add --no-cache \
     dpkg \


### PR DESCRIPTION
As this Package `ip` is not maintained anymore (last commit is 2 years ago)
We should remove this Package.
Testing due it break functionality but it shouldn't due our code don't use it.
Refs:
https://github.com/advisories/GHSA-78xj-cgh5-2h22
https://hub.docker.com/layers/library/node/18-alpine/images/sha256-affdf979bd8ec516bf189d451b8ac68dd50adc49adc4c4014963556c11efeda4?context=explore