### PR TITLE
feat: graceful shutdown

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -27,6 +27,11 @@ iptables -A FORWARD -o wg0 -j ACCEPT;
 `.split('\n').join(' ');
 
 module.exports.WG_PRE_DOWN = process.env.WG_PRE_DOWN || '';
-module.exports.WG_POST_DOWN = process.env.WG_POST_DOWN || '';
+module.exports.WG_POST_DOWN = process.env.WG_POST_DOWN || `
+iptables -t nat -D POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o ${module.exports.WG_DEVICE} -j MASQUERADE;
+iptables -D INPUT -p udp -m udp --dport 51820 -j ACCEPT;
+iptables -D FORWARD -i wg0 -j ACCEPT;
+iptables -D FORWARD -o wg0 -j ACCEPT;
+`.split('\n').join(' ');
 module.exports.LANG = process.env.LANG || 'en';
 module.exports.UI_TRAFFIC_STATS = process.env.UI_TRAFFIC_STATS || 'false';

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -318,4 +318,8 @@ Endpoint = ${WG_HOST}:${WG_PORT}`;
     await this.saveConfig();
   }
 
+  // Shutdown wireguard
+  async Shutdown() {
+    await Util.exec('wg-quick down wg0').catch(() => { });
+  }
 };

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -322,4 +322,5 @@ Endpoint = ${WG_HOST}:${WG_PORT}`;
   async Shutdown() {
     await Util.exec('wg-quick down wg0').catch(() => { });
   }
+
 };

--- a/src/server.js
+++ b/src/server.js
@@ -14,13 +14,16 @@ WireGuard.getConfig()
   });
 
 // Handle terminate signal
-process.on('SIGTERM', async() => {
+process.on('SIGTERM', async () => {
+  // eslint-disable-next-line no-console
   console.log('SIGTERM signal received.');
   await WireGuard.Shutdown();
+  // eslint-disable-next-line no-process-exit
   process.exit(0);
 });
 
 // Handle interupt signal
 process.on('SIGINT', () => {
+  // eslint-disable-next-line no-console
   console.log('SIGINT signal received.');
 });

--- a/src/server.js
+++ b/src/server.js
@@ -12,3 +12,15 @@ WireGuard.getConfig()
     // eslint-disable-next-line no-process-exit
     process.exit(1);
   });
+
+// Handle terminate signal
+process.on('SIGTERM', async() => {
+  console.log('SIGTERM signal received.');
+  await WireGuard.Shutdown();
+  process.exit(0);
+});
+
+// Handle interupt signal
+process.on('SIGINT', () => {
+  console.log('SIGINT signal received.');
+});


### PR DESCRIPTION
Lint errors fixed
From @samart45 Tested by @samart45 and @pheiduck

Fixes: https://github.com/wg-easy/wg-easy/issues/795
Fixes: https://github.com/wg-easy/wg-easy/issues/835
Issue duplicate firewall rules if network mode "host" is used:
```
/app # iptables  -v -L -n --line-numbers | grep "51820"
7        0     0 ACCEPT     17   --  *      *       0.0.0.0/0            0.0.0.0/0            udp dpt:51820
8        0     0 ACCEPT     17   --  *      *       0.0.0.0/0            0.0.0.0/0            udp dpt:51820
6        5   880 ACCEPT     17   --  *      *       0.0.0.0/0            0.0.0.0/0            udp dpt:51820
/app # iptables -v -L -n --line-numbers | grep "51821"
7       23  1380 ACCEPT     6    --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:51821
```