### PR TITLE
Fix detailed stats 3

### DIFF
--- a/src/www/index.html
+++ b/src/www/index.html
@@ -192,7 +192,7 @@
 
                     <!-- Info -->
                     <div v-if="uiDetailedStats"
-                      class="flex gap-2 items-center shrink-0 text-gray-400 dark:text-neutral-400 text-xs mt-px -ml-4 xxs:ml-0">
+                      class="flex gap-2 items-center shrink-0 text-gray-400 dark:text-neutral-400 text-xs mt-px justify-end">
 
                       <!-- Transfer TX -->
                       <div class="min-w-20 md:min-w-24" v-if="client.transferTx">


### PR DESCRIPTION
Aligned detailed stats block to the right on mobile.

There's another option - align everything to the left on mobile. Looks nice to me, what do you think?


<details>
  <summary>Right-aligned</summary>

  ![right](https://github.com/wg-easy/wg-easy/assets/19854626/f4289b52-53a7-4f8b-be48-fb8145db1732)

</details>


<details>
  <summary>Left-aligned</summary>

  ![left](https://github.com/wg-easy/wg-easy/assets/19854626/6c7b683d-c14d-4145-adea-0084bbdedc10)

</details>




