### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ FROM docker.io/library/node:18-alpine AS build_node_modules
 # Copy Web UI
 COPY src/ /app/
 WORKDIR /app
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev &&\
+    mv node_modules /node_modules
 
 # Copy build result to a new image.
 # This saves a lot of disk space.
@@ -20,13 +21,15 @@ COPY --from=build_node_modules /app /app
 # Also, some node_modules might be native, and
 # the architecture & OS of your development machine might differ
 # than what runs inside of docker.
-RUN mv /app/node_modules /node_modules
+COPY --from=build_node_modules /node_modules /node_modules
 
-# Enable this to run `npm run serve`
-RUN npm i -g nodemon
-
-# Workaround CVE-2023-42282
-RUN npm uninstall -g ip
+RUN \
+    # Enable this to run `npm run serve`
+    npm i -g nodemon &&\
+    # Workaround CVE-2023-42282
+    npm uninstall -g ip &&\
+    # Delete unnecessary files 
+    npm cache clean --force && rm -rf ~/.npm
 
 # Install Linux packages
 RUN apk add --no-cache \


### PR DESCRIPTION
This PR reduces the size of the resulting Docker image.

I noticed that the `node_modules` folder is first copied and then moved to the root directory of the container, taking up the same space in two different layers. This can be solved by moving it out of the `app` folder already in the first stage before copying it to the second stage.

Additionally, by combining the operations about `npm` into a single `RUN` statement we can clear its cache and delete some unnecessary log files.

These changes allow us to save just under **9MB**, or at least on the arm64 build I tried... _It ain't much but, it's honest work_