### PR TITLE
Use one command for updating with Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,11 @@ docker pull ghcr.io/wg-easy/wg-easy
 
 And then run the `docker run -d \ ...` command above again.
 
-To update using Docker Compose:
-
-```shell
-docker compose pull
-docker compose up --detach
-```
-
+With Docker Compose WireGuard Easy can be updated with a single command:
+`docker compose up --detach --pull always` (if an image tag is specified in the
+Compose file and it is not `latest`, make sure that it is changed to the desired
+one; by default it is omitted and
+[defaults to `latest`](https://docs.docker.com/engine/reference/run/#image-references)). \
 The WireGuared Easy container will be automatically recreated if a newer image
 was pulled.
 


### PR DESCRIPTION
`README.md` was updated to use a one-liner to update WireGuard Easy with Docker Compose.
A note about image tag was added to avoid confusion when one is specified in Compose file and it is other than `latest`, as that would result in no pull and no WireGuard Easy container recreation.

This pull request complements #901.