### PR TITLE
Add support for SVG and include proper Content-Type

### DIFF
--- a/src/lib/Server.js
+++ b/src/lib/Server.js
@@ -230,6 +230,7 @@ module.exports = class Server {
             if (id.endsWith('.json')) setHeader(event, 'Content-Type', 'application/json');
             if (id.endsWith('.css')) setHeader(event, 'Content-Type', 'text/css');
             if (id.endsWith('.png')) setHeader(event, 'Content-Type', 'image/png');
+            if (id.endsWith('.svg')) setHeader(event, 'Content-Type', 'image/svg+xml');
 
             return {
               size: stats.size,


### PR DESCRIPTION
I noticed #931 appearing on my [wg-easy instance](https://wg.dartegnian.com/) and [fork](https://github.com/Dartegnian/wg-easy-m3). I've seen #933 pushed and I'd like to request that the Content-Type for SVG be included since my fork uses SVGs. It can also help in advance if this project ever includes SVG files.