### PR TITLE
Security vulnerability patched and minor improvements

### DIFF
--- a/src/lib/Server.js
+++ b/src/lib/Server.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const bcrypt = require('bcryptjs');
 const crypto = require('node:crypto');
 const { createServer } = require('node:http');
 const { stat, readFile } = require('node:fs/promises');
@@ -116,15 +115,6 @@ module.exports = class Server {
 
         if (req.session && req.session.authenticated) {
           return next();
-        }
-
-        if (req.url.startsWith('/api/') && req.headers['authorization']) {
-          if (bcrypt.compareSync(req.headers['authorization'], bcrypt.hashSync(PASSWORD, 10))) {
-            return next();
-          }
-          return res.status(401).json({
-            error: 'Incorrect Password',
-          });
         }
 
         return res.status(401).json({

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -1,10 +1,9 @@
 'use strict';
 
-const fs = require('fs').promises;
+const fs = require('node:fs/promises');
 const path = require('path');
-
 const debug = require('debug')('WireGuard');
-const uuid = require('uuid');
+const crypto = require('node:crypto');
 const QRCode = require('qrcode');
 
 const Util = require('./Util');
@@ -248,7 +247,7 @@ Endpoint = ${WG_HOST}:${WG_PORT}`;
     }
 
     // Create Client
-    const id = uuid.v4();
+    const id = crypto.randomUUID();
     const client = {
       id,
       name,

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.1",
       "license": "GPL",
       "dependencies": {
-        "bcryptjs": "^2.4.3",
         "debug": "^4.3.4",
         "express-session": "^1.18.0",
         "h3": "^1.11.1",
@@ -908,11 +907,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -13,8 +13,7 @@
         "debug": "^4.3.4",
         "express-session": "^1.18.0",
         "h3": "^1.11.1",
-        "qrcode": "^1.5.3",
-        "uuid": "^9.0.1"
+        "qrcode": "^1.5.3"
       },
       "devDependencies": {
         "eslint-config-athom": "^3.1.3",
@@ -4625,18 +4624,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache": {
       "version": "2.4.0",

--- a/src/package.json
+++ b/src/package.json
@@ -13,7 +13,6 @@
   "author": "Emile Nijssen",
   "license": "GPL",
   "dependencies": {
-    "bcryptjs": "^2.4.3",
     "debug": "^4.3.4",
     "express-session": "^1.18.0",
     "h3": "^1.11.1",

--- a/src/package.json
+++ b/src/package.json
@@ -17,8 +17,7 @@
     "debug": "^4.3.4",
     "express-session": "^1.18.0",
     "h3": "^1.11.1",
-    "qrcode": "^1.5.3",
-    "uuid": "^9.0.1"
+    "qrcode": "^1.5.3"
   },
   "devDependencies": {
     "eslint-config-athom": "^3.1.3",

--- a/src/www/js/app.js
+++ b/src/www/js/app.js
@@ -390,9 +390,6 @@ new Vue({
           return releasesArray[0];
         });
 
-      console.log(`Current Release: ${currentRelease}`);
-      console.log(`Latest Release: ${latestRelease.version}`);
-
       if (currentRelease >= latestRelease.version) return;
 
       this.currentRelease = currentRelease;


### PR DESCRIPTION
In reference to #1067, this PR fixes the **directory traversal** (**path traversal**) vulnerability found in the last released version and introduced with bad path handling in the h3 framework's `serveStatic` directive. Now the requested resource paths are handled correctly with the `safePathJoin` function. It takes the base path of the static assets and the path to the requested resource and checks that their union is indeed still a valid **subpath**.

In addition, some minor improvements have been implemented:

- replaced the `uuid` package with the built-in Node `crypto` module. Since its only task was to generate **UUIDv4** for new clients, we can use the `randomUUID` function instead;
- removed the `bcryptjs` package. The only reason it was being used was to implement an authorization mechanism by checking that in the `Authorization` header of requests (beginning with `/api/`) there was the correct hash of the dashboard password. From what I've seen wg-easy handles authentication via **session cookies** instead, plus I can't find any part of the client code where that header is set, so I guess both the checking part and the module can be removed;
- stop printing the version of wg-easy in the browser console. I think there is no need to let anyone who visits the page without logging in know about it;