### PR TITLE
fix typo in Server.js

### DIFF
--- a/src/lib/Server.js
+++ b/src/lib/Server.js
@@ -103,7 +103,7 @@ module.exports = class Server {
 
         debug(`New Session: ${event.node.req.session.id}`);
 
-        return { succcess: true };
+        return { success: true };
       }));
 
     // WireGuard


### PR DESCRIPTION
While developing an API wrapper, I was so confused while checking for `success `but instead i always got just `succcess`.
Sorry, if this is considered as spam, just close it.
;)