### PR TITLE
feat: introduce PASSWORD_HASH and deprecate PASSWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To automatically install & run wg-easy, simply run:
   --name=wg-easy \
   -e LANG=de \
   -e WG_HOST=<🚨YOUR_SERVER_IP> \
-  -e PASSWORD=<🚨YOUR_ADMIN_PASSWORD> \
+  -e PASSWORD_HASH=<🚨YOUR_ADMIN_PASSWORD_HASH> \
   -e PORT=51821 \
   -e WG_PORT=51820 \
   -v ~/.wg-easy:/etc/wireguard \
@@ -80,7 +80,7 @@ To automatically install & run wg-easy, simply run:
 
 > 💡 Replace `YOUR_SERVER_IP` with your WAN IP, or a Dynamic DNS hostname.
 >
-> 💡 Replace `YOUR_ADMIN_PASSWORD` with a password to log in on the Web UI.
+> 💡 Replace `YOUR_ADMIN_PASSWORD_HASH` with a bycrpt hashed password to log in on the Web UI.
 
 The Web UI will now be available on `http://0.0.0.0:51821`.
 
@@ -102,7 +102,8 @@ These options can be configured by setting environment variables using `-e KEY="
 | - | - | - | - |
 | `PORT` | `51821` | `6789` | TCP port for Web UI. |
 | `WEBUI_HOST` | `0.0.0.0` | `localhost` | IP address web UI binds to. |
-| `PASSWORD` | - | `foobar123` | When set, requires a password when logging in to the Web UI. |
+| `PASSWORD_HASH` | - | `$2y$05$Ci...` | When set, requires a password when logging in to the Web UI. |
+| `PASSWORD` (deprecated) | - | `foobar123` | DO NOT USE IT! When set, requires a password when logging in to the Web UI. Prefer `PASSWORD_HASH` to not put the clear text password in the environment. If `PASSWORD_HASH` is set `PASSWORD` is ignored. |
 | `WG_HOST` | - | `vpn.myserver.com` | The public hostname of your VPN server. |
 | `WG_DEVICE` | `eth0` | `ens6f0` | Ethernet device the wireguard traffic should be forwarded through. |
 | `WG_PORT` | `51820` | `12345` | The public UDP port of your VPN server. WireGuard will listen on that (othwise default) inside the Docker container. |

--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,7 @@ module.exports.RELEASE = release;
 module.exports.PORT = process.env.PORT || '51821';
 module.exports.WEBUI_HOST = process.env.WEBUI_HOST || '0.0.0.0';
 module.exports.PASSWORD = process.env.PASSWORD;
+module.exports.PASSWORD_HASH = process.env.PASSWORD_HASH;
 module.exports.WG_PATH = process.env.WG_PATH || '/etc/wireguard/';
 module.exports.WG_DEVICE = process.env.WG_DEVICE || 'eth0';
 module.exports.WG_HOST = process.env.WG_HOST;

--- a/src/lib/Server.js
+++ b/src/lib/Server.js
@@ -37,6 +37,32 @@ const {
 
 const requiresPassword = !!PASSWORD || !!PASSWORD_HASH;
 
+/**
+ * Checks if `password` matches the PASSWORD_HASH.
+ *
+ * For backward compatibility it also allows `password` to match the clear text PASSWORD,
+ * but only if no PASSWORD_HASH is provided.
+ *
+ * If both enviornment variables are not set, the password is always invalid.
+ *
+ * @param {string} password String to test
+ * @returns {boolean} true if matching environment, otherwise false
+ */
+const isPasswordValid = (password) => {
+  if (typeof password !== 'string') {
+    return false;
+  }
+
+  if (PASSWORD_HASH) {
+    return bcrypt.compareSync(password, PASSWORD_HASH);
+  }
+  if (PASSWORD) {
+    return password === PASSWORD;
+  }
+
+  return false;
+};
+
 module.exports = class Server {
 
   constructor() {
@@ -101,7 +127,7 @@ module.exports = class Server {
             status: 401,
             message: 'Incorrect Password',
           });
-        };
+        }
 
         event.node.req.session.authenticated = true;
         event.node.req.session.save();
@@ -238,32 +264,6 @@ module.exports = class Server {
         message: 'Bad Request',
       });
     };
-
-    /**
-     * Checks if `password` matches the PASSWORD_HASH.
-     * 
-     * For backward compatibility it also allows `password` to match the clear text PASSWORD,
-     * but only if no PASSWORD_HASH is provided.
-     * 
-     * If both enviornment variables are not set, the password is always invalid.
-     * 
-     * @param {string} password String to test
-     * @returns {boolean} true if matching environment, otherwise false
-     */
-    const isPasswordValid = (password) => {
-      if (typeof password !== 'string') {
-        return false;
-      }
-
-      if (!!PASSWORD_HASH) {
-        return bcrypt.compareSync(password, PASSWORD_HASH);
-      }
-      if (!!PASSWORD) {
-        return password == PASSWORD;
-      }
-
-      return false;
-    }
 
     // Static assets
     const publicDir = '/app/www';

--- a/src/lib/Server.js
+++ b/src/lib/Server.js
@@ -29,10 +29,13 @@ const {
   WEBUI_HOST,
   RELEASE,
   PASSWORD,
+  PASSWORD_HASH,
   LANG,
   UI_TRAFFIC_STATS,
   UI_CHART_TYPE,
 } = require('../config');
+
+const requiresPassword = !!PASSWORD || !!PASSWORD_HASH;
 
 module.exports = class Server {
 
@@ -72,7 +75,6 @@ module.exports = class Server {
 
       // Authentication
       .get('/api/session', defineEventHandler((event) => {
-        const requiresPassword = !!process.env.PASSWORD;
         const authenticated = requiresPassword
           ? !!(event.node.req.session && event.node.req.session.authenticated)
           : true;
@@ -85,19 +87,21 @@ module.exports = class Server {
       .post('/api/session', defineEventHandler(async (event) => {
         const { password } = await readBody(event);
 
-        if (typeof password !== 'string') {
+        if (!requiresPassword) {
+          // if no password is required, the API should never be called.
+          // Do not automatically authenticate the user.
           throw createError({
             status: 401,
-            message: 'Missing: Password',
+            message: 'Invalid state',
           });
         }
 
-        if (password !== PASSWORD) {
+        if (!isPasswordValid(password)) {
           throw createError({
             status: 401,
             message: 'Incorrect Password',
           });
-        }
+        };
 
         event.node.req.session.authenticated = true;
         event.node.req.session.save();
@@ -110,7 +114,7 @@ module.exports = class Server {
     // WireGuard
     app.use(
       fromNodeMiddleware((req, res, next) => {
-        if (!PASSWORD || !req.url.startsWith('/api/')) {
+        if (!requiresPassword || !req.url.startsWith('/api/')) {
           return next();
         }
 
@@ -119,7 +123,7 @@ module.exports = class Server {
         }
 
         if (req.url.startsWith('/api/') && req.headers['authorization']) {
-          if (bcrypt.compareSync(req.headers['authorization'], bcrypt.hashSync(PASSWORD, 10))) {
+          if (isPasswordValid(req.headers['authorization'])) {
             return next();
           }
           return res.status(401).json({
@@ -234,6 +238,32 @@ module.exports = class Server {
         message: 'Bad Request',
       });
     };
+
+    /**
+     * Checks if `password` matches the PASSWORD_HASH.
+     * 
+     * For backward compatibility it also allows `password` to match the clear text PASSWORD,
+     * but only if no PASSWORD_HASH is provided.
+     * 
+     * If both enviornment variables are not set, the password is always invalid.
+     * 
+     * @param {string} password String to test
+     * @returns {boolean} true if matching environment, otherwise false
+     */
+    const isPasswordValid = (password) => {
+      if (typeof password !== 'string') {
+        return false;
+      }
+
+      if (!!PASSWORD_HASH) {
+        return bcrypt.compareSync(password, PASSWORD_HASH);
+      }
+      if (!!PASSWORD) {
+        return password == PASSWORD;
+      }
+
+      return false;
+    }
 
     // Static assets
     const publicDir = '/app/www';


### PR DESCRIPTION
Hey,

This implements `PASSWORD_HASH` and deprecates `PASSWORD` usage, because clear text passwords should not be part of any environment variable (neither in the container nor in the docker environment).  See #1105

Why do we have the tested password sourced from two different places?

1. `req.headers['authorization']`
2. `readBody(event)`

Anyway, I made the password validation DRY and moved it to `isPasswordValid`.

Kind regards
Robert