### PR TITLE
Fix bcrypt hash one-liner

### DIFF
--- a/How_to_generate_an_bcrypt_hash.md
+++ b/How_to_generate_an_bcrypt_hash.md
@@ -63,7 +63,7 @@ pip3 install bcrypt --break-system-packages
 ## Generating bcrypt hash from the command line
 You can use the following one-liner command to generate a bcrypt hash directly in the cmd/ terminal: 
 ```bash
-python3 -c "import bcrypt; password = b'your_password_here'; assert len(password) < 72, 'Password must be less than 72 bytes due to bcrypt limitation'; hashed = bcrypt.hashpw(password, bcrypt.gensalt()); print(f'The hashed password is: {hashed.decode()}'); docker_interpolation = hashed.decode().replace('$', '$$'); print(f'The hashed password for a Docker env is: {docker_interpolation}')" # or python if you run this on Windows. CHANGE your_password_here BY YOUR PASSWORD
+python3 -c "import bcrypt; password = b'your_password_here'; assert len(password) < 72, 'Password must be less than 72 bytes due to bcrypt limitation'; hashed = bcrypt.hashpw(password, bcrypt.gensalt()); print(f'The hashed password is: {hashed.decode()}'); docker_interpolation = hashed.decode().replace('$', '$'*2); print(f'The hashed password for a Docker env is: {docker_interpolation}')" # or python if you run this on Windows. CHANGE your_password_here BY YOUR PASSWORD
 ```
 Please change ``your_password_here`` in the line by your own password.
 


### PR DESCRIPTION
while, as expected:
```console
stevie@fedora:~$ echo '$$'
$$
```
because:
```console
stevie@fedora:~$ echo "$$"
6982
```
and:
```console
stevie@fedora:~$ echo "'$$'"
'6982'
```
The one-liner does not work in bash shell because the docker env version of the hashed password has the process id repeated everywhere there should be a `$$` in the hashed password.
## Proposed solution
Use the repetition operator in python to avoid any issues backslash escaping might cause across different hosts.
```python
docker_interpolation = hashed.decode().replace('$', '$$');  # Before
docker_interpolation = hashed.decode().replace('$', '$'*2); # After, using repetition operator to avoid $$ in double quotes
```