### PR TITLE
Automate IP Retrieval for Docker Run Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ If you haven't installed Docker yet, install it by running:
 ```bash
 curl -sSL https://get.docker.com | sh
 sudo usermod -aG docker $(whoami)
-exit
 ```
 
 And log in again.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To automatically install & run wg-easy, simply run:
 ```
   docker run -d \
   --name=wg-easy \
-  -e LANG=de \
+  -e LANG=en \
   -e WG_HOST=<🚨YOUR_SERVER_IP> \
   -e PASSWORD_HASH=<🚨YOUR_ADMIN_PASSWORD_HASH> \
   -e PORT=51821 \
@@ -121,7 +121,7 @@ These options can be configured by setting environment variables using `-e KEY="
 | `UI_TRAFFIC_STATS` | `false` | `true` | Enable detailed RX / TX client stats in Web UI                                                                                                       |
 | `UI_CHART_TYPE` | `0` | `1` | UI_CHART_TYPE=0 # Charts disabled, UI_CHART_TYPE=1 # Line chart, UI_CHART_TYPE=2 # Area chart, UI_CHART_TYPE=3 # Bar chart                           |
 
-> If you change `WG_PORT`, make sure to also change the exposed port.
+> If you change `WG_PORT`, make sure also to change the exposed port.
 
 ## Updating
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ If you haven't installed Docker yet, install it by running:
 ```bash
 curl -sSL https://get.docker.com | sh
 sudo usermod -aG docker $(whoami)
+exit
 ```
 
 And log in again.
@@ -59,10 +60,12 @@ And log in again.
 To automatically install & run wg-easy, simply run:
 
 ```
-  docker run -d \
+IP=$(curl -s http://checkip.amazonaws.com)
+
+docker run -d \
   --name=wg-easy \
   -e LANG=en \
-  -e WG_HOST=<🚨YOUR_SERVER_IP> \
+  -e WG_HOST=$IP \
   -e PASSWORD_HASH=<🚨YOUR_ADMIN_PASSWORD_HASH> \
   -e PORT=51821 \
   -e WG_PORT=51820 \


### PR DESCRIPTION
 Automatically retrieve and use the server's public IP address in the Docker run command

- Added a step to fetch the server's public IP address using curl dynamically.
- Updated the Docker run command to use the retrieved IP address for the WG_HOST environment variable.