### PR TITLE
Fix "invalid reference format" in production Docker build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set environment variables
-      run: echo RELEASE=$(cat ./src/package.json | jq -r .release) >> $GITHUB_ENV
+      run: echo RELEASE=$(cat ./src/package.json | jq -r .release | jq -r .version) >> $GITHUB_ENV
 
     - name: Build & Publish Docker Image
       uses: docker/build-push-action@v6


### PR DESCRIPTION
Hello! I've noticed that the package version format has now changed. The updated version in the [master branch package.json](https://github.com/wg-easy/wg-easy/tree/master/src/package.json) is now like this:

```json
"release": {
    "version": "13"
  },
```

From before:
```json
"release": "13",
```

Because of this, the Docker build pipeline fails and throws this error:
```
Error: buildx failed with: ERROR: invalid tag "***/wg-easy:{ \"version\": \"13\" }": invalid reference format
```

Fortunately, this issue is easy to solve. I took a look at the line of code in the [deploy.yml](https://github.com/wg-easy/wg-easy/tree/master/.github/workflows/deploy.yml#L36) file and specifically edited line 36. I made a small tweak that fixes the version fetching.

From:
```yml
run: echo RELEASE=$(cat ./src/package.json | jq -r .release) >> $GITHUB_ENV
```

To:
```yml
run: echo RELEASE=$(cat ./src/package.json | jq -r .release | jq -r .version) >> $GITHUB_ENV
```

Production has yet to encounter this error as the last build was 2 months ago, but I have my own fork that builds often and I encountered that bug when building. This was the same fix I used for my own fork.