### PR TITLE
Add autocomplete attribute to password input

### DIFF
--- a/src/www/index.html
+++ b/src/www/index.html
@@ -559,7 +559,7 @@
             </svg>
           </div>
 
-          <input type="password" name="password" :placeholder="$t('password')" v-model="password"
+          <input type="password" name="password" :placeholder="$t('password')" v-model="password" autocomplete="current-password"
             class="px-3 py-2 text-sm dark:bg-neutral-700 text-gray-500 dark:text-gray-500 mb-5 border-2 border-gray-100 dark:border-neutral-800 rounded-lg w-full focus:border-red-800 dark:focus:border-red-800 dark:placeholder:text-neutral-400 outline-none" />
 
           <button v-if="authenticating"


### PR DESCRIPTION
Safari suggests strong password on login page. This PR should fix this problem.

<img width="652" alt="strong password suggestion" src="https://github.com/user-attachments/assets/97468379-ffbc-4557-b11d-159cf399f3d7">
