### PR TITLE
Update How_to_generate_an_bcrypt_hash.md

### DIFF
--- a/How_to_generate_an_bcrypt_hash.md
+++ b/How_to_generate_an_bcrypt_hash.md
@@ -15,6 +15,9 @@ To generate a bcrypt password hash using docker, run the following command :
 docker run ghcr.io/wg-easy/wg-easy wgpw YOUR_PASSWORD
 PASSWORD_HASH='$2b$12$coPqCsPtcFO.Ab99xylBNOW4.Iu7OOA2/ZIboHN6/oyxca3MWo7fW' // literally YOUR_PASSWORD
 ```
+*Important*: in your configuration, make sure to use double "$", or your password may not work!
+In the example of password "YOUR_PASSWORD" you may write like this:
+PASSWORD_HASH=$$2b$$12$$coPqCsPtcFO.Ab99xylBNOW4.Iu7OOA2/ZIboHN6/oyxca3MWo7fW
 
 *Important* : make sure to enclose your password in single quotes when you run `docker run` command :
 


### PR DESCRIPTION
explain about double $ usage on password.
I lost 30 minutes trying to find why my generated password didn't work..
then, only after downloading the yaml I discovered it needs double "$".

it will help people for sure.