### PR TITLE
Add crossorigin attribute to manifest

### DIFF
--- a/src/www/index.html
+++ b/src/www/index.html
@@ -5,7 +5,7 @@
   <title>WireGuard</title>
   <meta charset="utf-8"/>
   <link href="./css/app.css" rel="stylesheet">
-  <link rel="manifest" href="./manifest.json">
+  <link rel="manifest" href="./manifest.json" crossorigin="use-credentials">
   <link rel="icon" type="image/png" href="./img/favicon.png">
   <link rel="apple-touch-icon" href="./img/apple-touch-icon.png">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">


### PR DESCRIPTION
I'm using basic auth for wg-easy and I noticed a trail of 401 status codes for the `/manifest.json` route.

This is a known issue, see e.g. https://github.com/koajs/basic-auth/issues/19#issuecomment-437050887 .
[MDN](https://developer.mozilla.org/en-US/docs/Web/Manifest) states:

> If the manifest requires credentials to fetch, the [crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) attribute must be set to use-credentials, even if the manifest file is in the same origin as the current page.

This PR adds the missing `use-credentials` attribute.