### PR TITLE
fix(Doc): fix escaping issue for PASSWORD_HASH in docker-compose.yml

### DIFF
--- a/How_to_generate_an_bcrypt_hash.md
+++ b/How_to_generate_an_bcrypt_hash.md
@@ -16,7 +16,7 @@ docker run ghcr.io/wg-easy/wg-easy wgpw YOUR_PASSWORD
 PASSWORD_HASH='$2b$12$coPqCsPtcFO.Ab99xylBNOW4.Iu7OOA2/ZIboHN6/oyxca3MWo7fW' // literally YOUR_PASSWORD
 ```
 
-*Important* : make sure to enclose your password in **single quotes** when you run `docker run` command :
+**Important** : make sure to enclose your password in **single quotes** when you run `docker run` command :
 
 ```bash
 $ echo $2b$12$coPqCsPtcF <-- not correct
@@ -26,3 +26,11 @@ b2
 $ echo '$2b$12$coPqCsPtcF' <-- correct
 $2b$12$coPqCsPtcF
 ```
+
+**Important** : Please note: don't wrap the generated hash password in single quotes when you use `docker-compose.yml`. Instead, replace each `$` symbol with two `$$` symbols. For example:
+
+``` yaml
+- PASSWORD_HASH=$$2y$$10$$hBCoykrB95WSzuV4fafBzOHWKu9sbyVa34GJr8VV5R/pIelfEMYyG
+```
+
+This hash is for the password 'foobar123', obtained using the command `docker run ghcr.io/wg-easy/wg-easy wgpw foobar123` and then inserted an additional `$` before each existing `$` symbal.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - WG_HOST=raspberrypi.local
 
       # Optional:
-      # - PASSWORD_HASH='$2y$10$hBCoykrB95WSzuV4fafBzOHWKu9sbyVa34GJr8VV5R/pIelfEMYyG' (hash of 'foobar123'; see "How_to_generate_an_bcrypt_hash.md" for generate the hash)
+      # - PASSWORD_HASH=$$2y$$10$$hBCoykrB95WSzuV4fafBzOHWKu9sbyVa34GJr8VV5R/pIelfEMYyG (needs double $$, hash of 'foobar123'; see "How_to_generate_an_bcrypt_hash.md" for generate the hash)
       # - PORT=51821
       # - WG_PORT=51820
       # - WG_CONFIG_PORT=92820


### PR DESCRIPTION
Hello! I noticed repeated changes to docker-compose.yml in previous commits. When applying the single-quote pattern, I encountered the following warning:

`WARN[0000] The "hBCoykrB95WSzuV4fafBzOHWKu9sbyVa34GJr8VV5R" variable is not set. Defaulting to a blank string.`

Additionally, the `PASSWORD_HASH` variable value was incorrect when viewed inside the container.

# Solution:
Remove the single quotes and insert an extra `$` before each existing `$`. After this modification, the program works as expected.

# Possible cause:
There might be inconsistencies in Docker Compose versions between us, leading to different behavior in handling escape characters.

My environment information:
```bash
docker --version
Docker version 27.1.1, build 6312585
docker compose version
Docker Compose version v2.29.1
```

The changes in this PR work correctly with my Docker Compose version. Please review and confirm if it also works properly with other versions.
#1261 
