### PR TITLE
[feature] amneziawg support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /config
 /wg0.conf
 /wg0.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,17 @@ services:
       # - ENABLE_PROMETHEUS_METRICS=false
       # - PROMETHEUS_METRICS_PASSWORD=$$2a$$12$$vkvKpeEAHD78gasyawIod.1leBMKg8sBwKW.pQyNsq78bXV3INf2G # (needs double $$, hash of 'prometheus_password'; see "How_to_generate_an_bcrypt_hash.md" for generate the hash)
 
+      # - WG_AMNEZIA_ENABLE=false
+      # - WG_AMNEZIA_JC=0
+      # - WG_AMNEZIA_JMIN=0
+      # - WG_AMNEZIA_JMAX=0
+      # - WG_AMNEZIA_S1=0
+      # - WG_AMNEZIA_S2=0
+      # - WG_AMNEZIA_H1=1
+      # - WG_AMNEZIA_H2=2
+      # - WG_AMNEZIA_H3=3
+      # - WG_AMNEZIA_H4=4
+
     image: ghcr.io/wg-easy/wg-easy
     container_name: wg-easy
     volumes:

--- a/src/config.js
+++ b/src/config.js
@@ -43,3 +43,14 @@ module.exports.UI_ENABLE_SORT_CLIENTS = process.env.UI_ENABLE_SORT_CLIENTS || 'f
 module.exports.WG_ENABLE_EXPIRES_TIME = process.env.WG_ENABLE_EXPIRES_TIME || 'false';
 module.exports.ENABLE_PROMETHEUS_METRICS = process.env.ENABLE_PROMETHEUS_METRICS || 'false';
 module.exports.PROMETHEUS_METRICS_PASSWORD = process.env.PROMETHEUS_METRICS_PASSWORD;
+
+module.exports.WG_AMNEZIA_ENABLE = process.env.WG_AMNEZIA_ENABLE || 'false';
+module.exports.WG_AMNEZIA_JC = process.env.WG_AMNEZIA_JC || 0;
+module.exports.WG_AMNEZIA_JMIN = process.env.WG_AMNEZIA_JMIN || 0;
+module.exports.WG_AMNEZIA_JMAX = process.env.WG_AMNEZIA_JMAX || 0;
+module.exports.WG_AMNEZIA_S1 = process.env.WG_AMNEZIA_S1 || 0;
+module.exports.WG_AMNEZIA_S2 = process.env.WG_AMNEZIA_S2 || 0;
+module.exports.WG_AMNEZIA_H1 = process.env.WG_AMNEZIA_H1 || 1;
+module.exports.WG_AMNEZIA_H2 = process.env.WG_AMNEZIA_H2 || 2;
+module.exports.WG_AMNEZIA_H3 = process.env.WG_AMNEZIA_H3 || 3;
+module.exports.WG_AMNEZIA_H4 = process.env.WG_AMNEZIA_H4 || 4;

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -26,6 +26,16 @@ const {
   WG_POST_DOWN,
   WG_ENABLE_EXPIRES_TIME,
   WG_ENABLE_ONE_TIME_LINKS,
+  WG_AMNEZIA_ENABLE,
+  WG_AMNEZIA_JC,
+  WG_AMNEZIA_JMIN,
+  WG_AMNEZIA_JMAX,
+  WG_AMNEZIA_S1,
+  WG_AMNEZIA_S2,
+  WG_AMNEZIA_H1,
+  WG_AMNEZIA_H2,
+  WG_AMNEZIA_H3,
+  WG_AMNEZIA_H4,
 } = require('../config');
 
 module.exports = class WireGuard {
@@ -218,6 +228,15 @@ PrivateKey = ${client.privateKey ? `${client.privateKey}` : 'REPLACE_ME'}
 Address = ${client.address}/24
 ${WG_DEFAULT_DNS ? `DNS = ${WG_DEFAULT_DNS}\n` : ''}\
 ${WG_MTU ? `MTU = ${WG_MTU}\n` : ''}\
+${WG_AMNEZIA_ENABLE === 'true' ? `Jc = ${WG_AMNEZIA_JC}
+Jmin = ${WG_AMNEZIA_JMIN}
+Jmax = ${WG_AMNEZIA_JMAX}
+S1 = ${WG_AMNEZIA_S1}
+S2 = ${WG_AMNEZIA_S2}
+H1 = ${WG_AMNEZIA_H1}
+H2 = ${WG_AMNEZIA_H2}
+H3 = ${WG_AMNEZIA_H3}
+H4 = ${WG_AMNEZIA_H4}` : ""}
 
 [Peer]
 PublicKey = ${config.server.publicKey}


### PR DESCRIPTION
Add support of amneziawg config [ref](https://github.com/amnezia-vpn)

## Description
Add config envs to client config file generation

## Motivation and Context
There is a DPI ban in some contries that blocks incomming packets via wireguard. This is one of the working clients, that helps avoid this. It sends junk random packets to prevent blocking. This packet generation controls via this params in client config file.

## How has this been tested?
via local env