### PR TITLE
Allow wgpw to prompt for a password through stdin

### DIFF
--- a/How_to_generate_an_bcrypt_hash.md
+++ b/How_to_generate_an_bcrypt_hash.md
@@ -15,6 +15,12 @@ To generate a bcrypt password hash using docker, run the following command :
 docker run ghcr.io/wg-easy/wg-easy wgpw YOUR_PASSWORD
 PASSWORD_HASH='$2b$12$coPqCsPtcFO.Ab99xylBNOW4.Iu7OOA2/ZIboHN6/oyxca3MWo7fW' // literally YOUR_PASSWORD
 ```
+If a password is not provided, the tool will prompt you for one :
+```sh
+docker run ghcr.io/wg-easy/wg-easy wgpw
+Enter your password:      // hidden prompt, type in your password
+PASSWORD_HASH='$2b$12$coPqCsPtcFO.Ab99xylBNOW4.Iu7OOA2/ZIboHN6/oyxca3MWo7fW'
+```
 
 **Important** : make sure to enclose your password in **single quotes** when you run `docker run` command :
 

--- a/src/wgpw.mjs
+++ b/src/wgpw.mjs
@@ -2,6 +2,8 @@
 
 // Import needed libraries
 import bcrypt from 'bcryptjs';
+import { Writable } from 'stream'
+import readline from 'readline'
 
 // Function to generate hash
 const generateHash = async (password) => {
@@ -31,12 +33,38 @@ const comparePassword = async (password, hash) => {
   }
 };
 
+const readStdinPassword = () => {
+
+  return new Promise((resolve) => {
+    process.stdout.write("Enter your password: ");
+
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: new Writable({
+        write(_chunk, _encoding, callback) {
+          callback()
+        }
+      }),
+      terminal: true,
+    });
+
+    rl.question('', answer => {
+      rl.close();
+      // Print a new line after password prompt
+      process.stdout.write('\n');
+      resolve(answer);
+    })
+
+  })
+
+}
+
 (async () => {
   try {
     // Retrieve command line arguments
     const args = process.argv.slice(2); // Ignore the first two arguments
     if (args.length > 2) {
-      throw new Error('Usage : wgpw YOUR_PASSWORD [HASH]');
+      throw new Error('Usage : wgpw [YOUR_PASSWORD] [HASH]');
     }
 
     const [password, hash] = args;
@@ -44,6 +72,9 @@ const comparePassword = async (password, hash) => {
       await comparePassword(password, hash);
     } else if (password) {
       await generateHash(password);
+    } else {
+      const password = await readStdinPassword();
+      await generateHash(password)
     }
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/src/wgpw.mjs
+++ b/src/wgpw.mjs
@@ -2,8 +2,8 @@
 
 // Import needed libraries
 import bcrypt from 'bcryptjs';
-import { Writable } from 'stream'
-import readline from 'readline'
+import { Writable } from 'stream';
+import readline from 'readline';
 
 // Function to generate hash
 const generateHash = async (password) => {
@@ -34,30 +34,27 @@ const comparePassword = async (password, hash) => {
 };
 
 const readStdinPassword = () => {
-
   return new Promise((resolve) => {
-    process.stdout.write("Enter your password: ");
+    process.stdout.write('Enter your password: ');
 
     const rl = readline.createInterface({
       input: process.stdin,
       output: new Writable({
         write(_chunk, _encoding, callback) {
-          callback()
-        }
+          callback();
+        },
       }),
       terminal: true,
     });
 
-    rl.question('', answer => {
+    rl.question('', (answer) => {
       rl.close();
       // Print a new line after password prompt
       process.stdout.write('\n');
       resolve(answer);
-    })
-
-  })
-
-}
+    });
+  });
+};
 
 (async () => {
   try {
@@ -74,7 +71,7 @@ const readStdinPassword = () => {
       await generateHash(password);
     } else {
       const password = await readStdinPassword();
-      await generateHash(password)
+      await generateHash(password);
     }
   } catch (error) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
## Description
The changes are contained in `src/wgpw.mjs`. The password parameter is now also optional.
If the user does not provide any arguments, the tool will default to generating a hash and  prompt the user for a password through `stdin`.
The password is not echoed back, just like any other command-line log-in prompt (ie. sudo).

## Motivation and Context
This is done to avoid having the password written to the user's shell history in plain text. Just a security consideration.

## How has this been tested?
These changes only affect `wgpw`.
It has been tested by building the docker image in Fedora using Podman.
All combinations of arguments have been tested. It still generates a hash when given a password through the arguments list. It still validates a hash if given as a second argument, comparing it to the first argument.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
