### PR TITLE
Feat: Improve Database Handling

### DIFF
--- a/src/server/middleware/session.ts
+++ b/src/server/middleware/session.ts
@@ -11,11 +11,6 @@ export default defineEventHandler(async (event) => {
     return;
   }
   const system = await Database.system.get();
-  if (!system)
-    throw createError({
-      statusCode: 500,
-      statusMessage: 'Invalid',
-    });
 
   const session = await getSession(event, system.sessionConfig);
   if (session.id && session.data.authenticated) {

--- a/src/server/utils/Database.ts
+++ b/src/server/utils/Database.ts
@@ -5,11 +5,21 @@
 
 import LowDb from '~~/services/database/lowdb';
 
-const provider = new LowDb();
+const nullObject = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error('Database not yet initialized');
+    },
+  }
+);
 
-provider.connect().catch((err) => {
-  console.error(err);
-  process.exit(1);
+// eslint-disable-next-line import/no-mutable-exports
+let provider = nullObject as never as LowDb;
+
+LowDb.connect().then((v) => {
+  provider = v;
+  WireGuard.Startup();
 });
 
 // TODO: check if old config exists and tell user about migration path

--- a/src/server/utils/WireGuard.ts
+++ b/src/server/utils/WireGuard.ts
@@ -28,17 +28,17 @@ class WireGuard {
       result.push(wg.generateServerPeer(client));
     }
 
-    DEBUG('Config saving...');
+    DEBUG('Saving Config...');
     await fs.writeFile('/etc/wireguard/wg0.conf', result.join('\n\n'), {
       mode: 0o600,
     });
-    DEBUG('Config saved.');
+    DEBUG('Config saved successfully.');
   }
 
   async #syncWireguardConfig() {
-    DEBUG('Config syncing...');
+    DEBUG('Syncing Config...');
     await wg.sync();
-    DEBUG('Config synced.');
+    DEBUG('Config synced successfully.');
   }
 
   async getClients() {
@@ -275,16 +275,7 @@ class WireGuard {
   }
 
   async Startup() {
-    // TODO: improve this
-    await new Promise((res) => {
-      function wait() {
-        if (Database.connected) {
-          return res(true);
-        }
-      }
-      setTimeout(wait, 1000);
-    });
-    DEBUG('Starting Wireguard');
+    DEBUG('Starting Wireguard...');
     await this.#saveWireguardConfig();
     await wg.down().catch(() => {});
     await wg.up().catch((err) => {
@@ -301,10 +292,11 @@ class WireGuard {
       throw err;
     });
     await this.#syncWireguardConfig();
-    DEBUG('Wireguard started successfully');
+    DEBUG('Wireguard started successfully.');
 
-    DEBUG('Starting Cron Job');
+    DEBUG('Starting Cron Job.');
     await this.startCronJob();
+    DEBUG('Cron Job started successfully.');
   }
 
   async startCronJob() {
@@ -426,10 +418,4 @@ class WireGuard {
   }
 }
 
-const inst = new WireGuard();
-inst.Startup().catch((v) => {
-  console.error(v);
-  process.exit(1);
-});
-
-export default inst;
+export default new WireGuard();

--- a/src/server/utils/session.ts
+++ b/src/server/utils/session.ts
@@ -6,6 +6,5 @@ export type WGSession = {
 
 export async function useWGSession(event: H3Event) {
   const system = await Database.system.get();
-  if (!system) throw new Error('Invalid');
   return useSession<Partial<WGSession>>(event, system.sessionConfig);
 }

--- a/src/services/database/repositories/database.ts
+++ b/src/services/database/repositories/database.ts
@@ -28,7 +28,9 @@ export abstract class DatabaseProvider {
   /**
    * Connects to the database.
    */
-  abstract connect(): Promise<void>;
+  static connect(): Promise<DatabaseProvider> {
+    throw new Error('Not implemented');
+  }
 
   /**
    * Disconnects from the database.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This improves Database handling and DX.
Instead of praying that `#db` is set. This throws a Error message such that the frontend shows a 500 page and users know that the "Database [is] not yet initialized".
And if in the backend a function didn't wait properly for the Database (and action is not made from user) it will crash the server.
This should avoid any undefined state where e.g. migrations are not done.
The WireGuard Interface is now started after DB is connected instead of having to poll the connection state

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix weird issues

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Locally

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
