### PR TITLE
Add support advanced security settings (AmneziaWG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,25 @@ These options can be configured by setting environment variables using `-e KEY="
 
 > If you change `WG_PORT`, make sure to also change the exposed port.
 
+### Advanced security settings ([AmneziaWG](https://docs.amnezia.org/documentation/amnezia-wg/) only)
+If defined `WG_ASC_JC` then advanced security settings will be enabled.
+All options are required.
+
+| Env           | Default | Example | Description                                                                                                            |
+|---------------|---------|---------|------------------------------------------------------------------------------------------------------------------------|
+| `WG_ASC_JC`   | -       | `4`     | If defined, ASC will be enabled. Recommended range is from 3 to 10 inclusive                                           |
+| `WG_ASC_JMIN` | -       | `50`    | Jmin < Jmax; recommended value is 50                                                                                   |
+| `WG_ASC_JMAX` | -       | `1000`  | Jmin < Jmax ≤ 1280; recommended value is 1000                                                                          |
+| `WG_ASC_S1`   | -       | `20`    | < 1280; recommended range is from 15 to 150 inclusive                                                                  |
+| `WG_ASC_S2`   | -       | `80`    | < 1280; recommended range is from 15 to 150 inclusive                                                                  |
+| `WG_ASC_H1`   | -       | `465374418` | Must be unique among each other H*; recommended range is from 5 to 2147483647 inclusive                                |
+| `WG_ASC_H2`   | -       | `87847148` | Must be unique among each other H*; recommended range is from 5 to 2147483647 inclusive
+| `WG_ASC_H3`   | -       | `1143494632`  | Must be unique among each other H*; recommended range is from 5 to 2147483647 inclusive                                                             |
+| `WG_ASC_H4`   | -       | `411102977`    | Must be unique among each other H*; recommended range is from 5 to 2147483647 inclusive              |
+
+> Works only with [AmneziaWG](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module) and currently not compatible with Docker version.
+
+
 ## Updating
 
 To update to the latest version, simply run:

--- a/src/config.js
+++ b/src/config.js
@@ -37,6 +37,17 @@ iptables -D INPUT -p udp -m udp --dport ${module.exports.WG_PORT} -j ACCEPT;
 iptables -D FORWARD -i wg0 -j ACCEPT;
 iptables -D FORWARD -o wg0 -j ACCEPT;
 `.split('\n').join(' ');
+// Advanced security settings
+module.exports.WG_ASC_JC = process.env.WG_ASC_JC;
+module.exports.WG_ASC_JMIN = process.env.WG_ASC_JMIN
+module.exports.WG_ASC_JMAX = process.env.WG_ASC_JMAX
+module.exports.WG_ASC_S1 = process.env.WG_ASC_S1;
+module.exports.WG_ASC_S2 = process.env.WG_ASC_S2;
+module.exports.WG_ASC_H1 = process.env.WG_ASC_H1;
+module.exports.WG_ASC_H2 = process.env.WG_ASC_H2;
+module.exports.WG_ASC_H3 = process.env.WG_ASC_H3;
+module.exports.WG_ASC_H4 = process.env.WG_ASC_H4;
+
 module.exports.LANG = process.env.LANG || 'en';
 module.exports.UI_TRAFFIC_STATS = process.env.UI_TRAFFIC_STATS || 'false';
 module.exports.UI_CHART_TYPE = process.env.UI_CHART_TYPE || 0;

--- a/src/lib/Server.js
+++ b/src/lib/Server.js
@@ -398,7 +398,7 @@ module.exports = class Server {
       }));
 
     // Static assets
-    const publicDir = '/app/www';
+    const publicDir = resolve(__dirname, '..', 'www');
     app.use(
       defineEventHandler((event) => {
         return serveStatic(event, {

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -26,6 +26,9 @@ const {
   WG_POST_DOWN,
   WG_ENABLE_EXPIRES_TIME,
   WG_ENABLE_ONE_TIME_LINKS,
+  WG_ASC_JC, WG_ASC_JMIN, WG_ASC_JMAX,
+  WG_ASC_S1, WG_ASC_S2,
+  WG_ASC_H1, WG_ASC_H2, WG_ASC_H3, WG_ASC_H4,
 } = require('../config');
 
 module.exports = class WireGuard {
@@ -110,6 +113,21 @@ PostUp = ${WG_POST_UP}
 PreDown = ${WG_PRE_DOWN}
 PostDown = ${WG_POST_DOWN}
 `;
+    // Has advanced security config
+    if (WG_ASC_JC) {
+      result += `
+# Advance security
+Jc = ${WG_ASC_JC}
+Jmin = ${WG_ASC_JMIN}
+Jmax = ${WG_ASC_JMAX}
+S1 = ${WG_ASC_S1}
+S2 = ${WG_ASC_S2}
+H1 = ${WG_ASC_H1}
+H2 = ${WG_ASC_H2}
+H3 = ${WG_ASC_H3}
+H4 = ${WG_ASC_H4}
+`;
+    }
 
     for (const [clientId, client] of Object.entries(config.clients)) {
       if (!client.enabled) continue;
@@ -211,13 +229,23 @@ ${client.preSharedKey ? `PresharedKey = ${client.preSharedKey}\n` : ''
   async getClientConfiguration({ clientId }) {
     const config = await this.getConfig();
     const client = await this.getClient({ clientId });
-
+    const asc = WG_ASC_JC ? `
+Jc = ${WG_ASC_JC}
+Jmin = ${WG_ASC_JMIN}
+Jmax = ${WG_ASC_JMAX}
+S1 = ${WG_ASC_S1}
+S2 = ${WG_ASC_S2}
+H1 = ${WG_ASC_H1}
+H2 = ${WG_ASC_H2}
+H3 = ${WG_ASC_H3}
+H4 = ${WG_ASC_H4}` : '';
     return `
 [Interface]
 PrivateKey = ${client.privateKey ? `${client.privateKey}` : 'REPLACE_ME'}
 Address = ${client.address}/24
 ${WG_DEFAULT_DNS ? `DNS = ${WG_DEFAULT_DNS}\n` : ''}\
 ${WG_MTU ? `MTU = ${WG_MTU}\n` : ''}\
+${asc}
 
 [Peer]
 PublicKey = ${config.server.publicKey}


### PR DESCRIPTION
Add support [AmneziaWG](https://github.com/amnezia-vpn/amneziawg-go) security settings 

## Description
I have add support AmneziaWG parameters to the config generator. It allows to define it via `WG_ASC_*` environment variables. See [description](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module?tab=readme-ov-file#configuration).

```
WG_ASC_JC
WG_ASC_JMIN
WG_ASC_JMAX
WG_ASC_S1
WG_ASC_S2
WG_ASC_H1
WG_ASC_H2
WG_ASC_H3
WG_ASC_H4
```

Also fixed hardcoded assets path for possibility to run not only from /app path. 