### PR TITLE
Install kmod from repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apk add --no-cache \
     dumb-init \
     iptables \
     ip6tables \
+    kmod \
     iptables-legacy \
     wireguard-tools
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -18,6 +18,7 @@ RUN apk add --no-cache \
     dumb-init \
     iptables \
     ip6tables \
+    kmod \
     iptables-legacy \
     wireguard-tools
 


### PR DESCRIPTION
Because the busybox modprobe utility is unable to load zstd compressed modules.

On ubuntu 24.04LTS uses zstd compression for the modules

## Motivation and Context

This change makes IPv6 and wg-test work on ubuntu 24.04LTS and probably other modern distros

## How has this been tested?
Tested on ubuntu 24.04LTS

