### PR TITLE
Add serverAllowedIPs,clientAllowedIPs,clientPreUP,clientPostUp,clientPreDown,clientPostDown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ COPY --from=build_node_modules /node_modules /node_modules
 COPY --from=build_node_modules /app/wgpw.sh /bin/wgpw
 RUN chmod +x /bin/wgpw
 
+# Use Tencent Mirrors
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.cloud.tencent.com/g' /etc/apk/repositories
+
 # Install Linux packages
 RUN apk add --no-cache \
     dpkg \

--- a/build-wg-easy.sh
+++ b/build-wg-easy.sh
@@ -1,0 +1,2 @@
+﻿#/bin/bash
+docker build -t wg-easy .

--- a/build-wg-easy.sh
+++ b/build-wg-easy.sh
@@ -1,2 +1,2 @@
-﻿#/bin/bash
+﻿#！/bin/bash
 docker build -t wg-easy .

--- a/build-wg-easy.sh
+++ b/build-wg-easy.sh
@@ -1,2 +1,2 @@
-﻿#！/bin/bash
+﻿#!/bin/bash
 docker build -t wg-easy .

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -120,7 +120,7 @@ PostDown = ${WG_POST_DOWN}
 [Peer]
 PublicKey = ${client.publicKey}
 ${client.preSharedKey ? `PresharedKey = ${client.preSharedKey}\n` : ''
-}AllowedIPs = ${client.address}/32`;
+}AllowedIPs = ${client.allowedIPs? client.allowedIPs:(client.address+'/32')}`;
     }
 
     debug('Config saving...');
@@ -250,6 +250,7 @@ Endpoint = ${WG_HOST}:${WG_CONFIG_PORT}`;
 
     // Calculate next IP
     let address;
+    let allowedIps;
     for (let i = 2; i < 255; i++) {
       const client = Object.values(config.clients).find((client) => {
         return client.address === WG_DEFAULT_ADDRESS.replace('x', i);
@@ -257,6 +258,7 @@ Endpoint = ${WG_HOST}:${WG_CONFIG_PORT}`;
 
       if (!client) {
         address = WG_DEFAULT_ADDRESS.replace('x', i);
+        allowedIps = address + '/32';
         break;
       }
     }
@@ -264,12 +266,14 @@ Endpoint = ${WG_HOST}:${WG_CONFIG_PORT}`;
     if (!address) {
       throw new Error('Maximum number of clients reached.');
     }
+
     // Create Client
     const id = crypto.randomUUID();
     const client = {
       id,
       name,
       address,
+      allowedIps,
       privateKey,
       publicKey,
       preSharedKey,

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -120,7 +120,7 @@ PostDown = ${WG_POST_DOWN}
 [Peer]
 PublicKey = ${client.publicKey}
 ${client.preSharedKey ? `PresharedKey = ${client.preSharedKey}\n` : ''
-}AllowedIPs = ${client.allowedIPs? client.allowedIPs:(client.address+'/32')}`;
+}AllowedIPs = ${client.serverAllowedIPs}`;
     }
 
     debug('Config saving...');
@@ -152,10 +152,15 @@ ${client.preSharedKey ? `PresharedKey = ${client.preSharedKey}\n` : ''
       expiredAt: client.expiredAt !== null
         ? new Date(client.expiredAt)
         : null,
-      allowedIPs: client.allowedIPs,
+      serverAllowedIPs: client.serverAllowedIPs,
+      clientAllowedIPs: client.clientAllowedIPs,
       oneTimeLink: client.oneTimeLink ?? null,
       oneTimeLinkExpiresAt: client.oneTimeLinkExpiresAt ?? null,
       downloadableConfig: 'privateKey' in client,
+      clientPreUP: client.clientPreUP ?? null,
+      clientPostUp: client.clientPostUp ?? null,
+      clientPreDown: client.clientPreDown ?? null,
+      clientPostDown: client.clientPostDown ?? null,
       persistentKeepalive: null,
       latestHandshakeAt: null,
       transferRx: null,
@@ -218,11 +223,16 @@ PrivateKey = ${client.privateKey ? `${client.privateKey}` : 'REPLACE_ME'}
 Address = ${client.address}/24
 ${WG_DEFAULT_DNS ? `DNS = ${WG_DEFAULT_DNS}\n` : ''}\
 ${WG_MTU ? `MTU = ${WG_MTU}\n` : ''}\
+${client.clientPreUP ? `PreUp = ${client.clientPreUP}\n` : ''}\
+${client.clientPostUp ? `PostUp = ${client.clientPostUp}\n` : ''}\
+${client.clientPreDown ? `PreDown = ${client.clientPreDown}\n` : ''}\
+${client.clientPostDown ? `PostDown = ${client.clientPostDown}\n` : ''}\
+
 
 [Peer]
 PublicKey = ${config.server.publicKey}
 ${client.preSharedKey ? `PresharedKey = ${client.preSharedKey}\n` : ''
-}AllowedIPs = ${WG_ALLOWED_IPS}
+}AllowedIPs = ${client.clientAllowedIPs}
 PersistentKeepalive = ${WG_PERSISTENT_KEEPALIVE}
 Endpoint = ${WG_HOST}:${WG_CONFIG_PORT}`;
   }
@@ -250,7 +260,8 @@ Endpoint = ${WG_HOST}:${WG_CONFIG_PORT}`;
 
     // Calculate next IP
     let address;
-    let allowedIps;
+    let serverAllowedIPs;
+    let clientAllowedIPs;
     for (let i = 2; i < 255; i++) {
       const client = Object.values(config.clients).find((client) => {
         return client.address === WG_DEFAULT_ADDRESS.replace('x', i);
@@ -258,7 +269,8 @@ Endpoint = ${WG_HOST}:${WG_CONFIG_PORT}`;
 
       if (!client) {
         address = WG_DEFAULT_ADDRESS.replace('x', i);
-        allowedIps = address + '/32';
+        serverAllowedIPs = address + '/32';
+        clientAllowedIPs = WG_ALLOWED_IPS;
         break;
       }
     }
@@ -273,13 +285,18 @@ Endpoint = ${WG_HOST}:${WG_CONFIG_PORT}`;
       id,
       name,
       address,
-      allowedIps,
+      serverAllowedIPs,
+      clientAllowedIPs,
       privateKey,
       publicKey,
       preSharedKey,
 
       createdAt: new Date(),
       updatedAt: new Date(),
+      clientPreUP: null,
+      clientPostUp: null,
+      clientPreDown: null,
+      clientPostDown: null,
       expiredAt: null,
       enabled: true,
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add serverAllowedIPs,clientAllowedIPs,clientPreUP,clientPostUp,clientPreDown,clientPostDown for config file wg0.json
## Description
<!--- Describe your changes in detail -->
+ Add serverAllowedIPs,clientAllowedIPs,clientPreUP,clientPostUp,clientPreDown,clientPostDown in `src/lib/WireGuard.js`
+ Add docker build script 
+ The change of Dockerfile can be ignored,it just for china mainland
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before these changes, some configuration of wg0.conf will be losses after docker restarted, such as Peer's AllowedIPs.Also, client's configuration like AllowedIPs,PreUP,PostUp,PreDown,PostDown did not return to config file.This pull request can solve those.
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I deploy modified wg-easy on my server, and create client by web ui. Then i modify wg0.json to add serverAllowedIPs,clientAllowedIPs,PreUP,PostUp,PreDown,PostDown. After the docker restarted, the AllowedIPs (serverAllowedIPs in wg0.json) under Peers did not loss.
I download the config file from web ui, the config file also include AllowedIPs (clientAllowedIPs in wg0.js),PreUP,PostUp,PreDown,PostDown.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
