### PR TITLE
Chore: Remove multi interface support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
-/config
-/wg0.conf
-/wg0.json
-/src/node_modules
 .DS_Store
 *.swp

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -23,4 +23,4 @@ logs
 .env.*
 !.env.example
 
-wg0.db
+wg-easy.db

--- a/src/drizzle.config.ts
+++ b/src/drizzle.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   schema: './server/database/schema.ts',
   dialect: 'sqlite',
   dbCredentials: {
-    url: 'file:./wg0.db',
+    url: 'file:./wg-easy.db',
   },
 });

--- a/src/server/api/admin/hooks.get.ts
+++ b/src/server/api/admin/hooks.get.ts
@@ -1,7 +1,4 @@
 export default definePermissionEventHandler(actions.ADMIN, async () => {
-  const hooks = await Database.hooks.get('wg0');
-  if (!hooks) {
-    throw new Error('Hooks not found');
-  }
+  const hooks = await Database.hooks.get();
   return hooks;
 });

--- a/src/server/api/admin/hooks.post.ts
+++ b/src/server/api/admin/hooks.post.ts
@@ -7,7 +7,7 @@ export default definePermissionEventHandler(
       event,
       validateZod(HooksUpdateSchema, event)
     );
-    await Database.hooks.update('wg0', data);
+    await Database.hooks.update(data);
     await WireGuard.saveConfig();
     return { success: true };
   }

--- a/src/server/api/admin/interface/cidr.post.ts
+++ b/src/server/api/admin/interface/cidr.post.ts
@@ -8,7 +8,7 @@ export default definePermissionEventHandler(
       validateZod(InterfaceCidrUpdateSchema, event)
     );
 
-    await Database.interfaces.updateCidr('wg0', data);
+    await Database.interfaces.updateCidr(data);
     await WireGuard.saveConfig();
     return { success: true };
   }

--- a/src/server/api/admin/interface/index.get.ts
+++ b/src/server/api/admin/interface/index.get.ts
@@ -1,9 +1,5 @@
 export default definePermissionEventHandler(actions.ADMIN, async () => {
-  const wgInterface = await Database.interfaces.get('wg0');
-
-  if (!wgInterface) {
-    throw new Error('Interface not found');
-  }
+  const wgInterface = await Database.interfaces.get();
 
   return {
     ...wgInterface,

--- a/src/server/api/admin/interface/index.post.ts
+++ b/src/server/api/admin/interface/index.post.ts
@@ -7,7 +7,7 @@ export default definePermissionEventHandler(
       event,
       validateZod(InterfaceUpdateSchema, event)
     );
-    await Database.interfaces.update('wg0', data);
+    await Database.interfaces.update(data);
     await WireGuard.saveConfig();
     return { success: true };
   }

--- a/src/server/api/admin/userconfig.get.ts
+++ b/src/server/api/admin/userconfig.get.ts
@@ -1,7 +1,4 @@
 export default definePermissionEventHandler(actions.ADMIN, async () => {
-  const userConfig = await Database.userConfigs.get('wg0');
-  if (!userConfig) {
-    throw new Error('User config not found');
-  }
+  const userConfig = await Database.userConfigs.get();
   return userConfig;
 });

--- a/src/server/api/admin/userconfig.post.ts
+++ b/src/server/api/admin/userconfig.post.ts
@@ -7,7 +7,7 @@ export default definePermissionEventHandler(
       event,
       validateZod(UserConfigUpdateSchema, event)
     );
-    await Database.userConfigs.update('wg0', data);
+    await Database.userConfigs.update(data);
     await WireGuard.saveConfig();
     return { success: true };
   }

--- a/src/server/api/setup/5.post.ts
+++ b/src/server/api/setup/5.post.ts
@@ -5,7 +5,7 @@ export default defineSetupEventHandler(async ({ event }) => {
     event,
     validateZod(UserConfigSetupSchema, event)
   );
-  await Database.userConfigs.updateHostPort('wg0', host, port);
+  await Database.userConfigs.updateHostPort(host, port);
   await Database.general.setSetupStep(0);
   return { success: true };
 });

--- a/src/server/database/repositories/hooks/service.ts
+++ b/src/server/database/repositories/hooks/service.ts
@@ -20,15 +20,19 @@ export class HooksService {
     this.#statements = createPreparedStatement(db);
   }
 
-  get(infName: string) {
-    return this.#statements.get.execute({ interface: infName });
+  async get() {
+    const hooks = await this.#statements.get.execute({ interface: 'wg0' });
+    if (!hooks) {
+      throw new Error('Hooks not found');
+    }
+    return hooks;
   }
 
-  update(infName: string, data: HooksUpdateType) {
+  update(data: HooksUpdateType) {
     return this.#db
       .update(hooks)
       .set(data)
-      .where(eq(hooks.id, infName))
+      .where(eq(hooks.id, 'wg0'))
       .execute();
   }
 }

--- a/src/server/database/repositories/interface/schema.ts
+++ b/src/server/database/repositories/interface/schema.ts
@@ -13,6 +13,7 @@ export const wgInterface = sqliteTable('interfaces_table', {
   ipv4Cidr: text('ipv4_cidr').notNull(),
   ipv6Cidr: text('ipv6_cidr').notNull(),
   mtu: int().notNull(),
+  // does nothing yet
   enabled: int({ mode: 'boolean' }).notNull(),
   createdAt: text('created_at')
     .notNull()

--- a/src/server/database/repositories/userConfig/service.ts
+++ b/src/server/database/repositories/userConfig/service.ts
@@ -28,23 +28,29 @@ export class UserConfigService {
     this.#statements = createPreparedStatement(db);
   }
 
-  get(infName: string) {
-    return this.#statements.get.execute({ interface: infName });
+  async get() {
+    const userConfig = await this.#statements.get.execute({ interface: 'wg0' });
+
+    if (!userConfig) {
+      throw new Error('User config not found');
+    }
+
+    return userConfig;
   }
 
-  updateHostPort(infName: string, host: string, port: number) {
+  updateHostPort(host: string, port: number) {
     return this.#statements.updateHostPort.execute({
-      interface: infName,
+      interface: 'wg0',
       host,
       port,
     });
   }
 
-  update(infName: string, data: UserConfigUpdateType) {
+  update(data: UserConfigUpdateType) {
     return this.#db
       .update(userConfig)
       .set(data)
-      .where(eq(userConfig.id, infName))
+      .where(eq(userConfig.id, 'wg0'))
       .execute();
   }
 }

--- a/src/server/database/sqlite.ts
+++ b/src/server/database/sqlite.ts
@@ -14,7 +14,7 @@ import { OneTimeLinkService } from './repositories/oneTimeLink/service';
 
 const DB_DEBUG = debug('Database');
 
-const client = createClient({ url: 'file:/etc/wireguard/wg0.db' });
+const client = createClient({ url: 'file:/etc/wireguard/wg-easy.db' });
 const db = drizzle({ client, schema });
 
 export async function connect() {

--- a/src/server/routes/metrics/prometheus.get.ts
+++ b/src/server/routes/metrics/prometheus.get.ts
@@ -4,6 +4,7 @@ export default defineMetricsHandler('prometheus', async ({ event }) => {
 });
 
 async function getPrometheusResponse() {
+  const wgInterface = await Database.interfaces.get();
   const clients = await WireGuard.getClients();
   let wireguardPeerCount = 0;
   let wireguardEnabledPeersCount = 0;
@@ -21,7 +22,7 @@ async function getPrometheusResponse() {
       wireguardConnectedPeersCount++;
     }
 
-    const id = `interface="wg0",enabled="${client.enabled}",ipv4Address="${client.ipv4Address}",ipv6Address="${client.ipv6Address}",name="${client.name}"`;
+    const id = `interface="${wgInterface.name}",enabled="${client.enabled}",ipv4Address="${client.ipv4Address}",ipv6Address="${client.ipv6Address}",name="${client.name}"`;
 
     wireguardSentBytes.push(
       `wireguard_sent_bytes{${id}} ${client.transferTx ?? 0}`
@@ -35,20 +36,22 @@ async function getPrometheusResponse() {
     );
   }
 
+  const id = `interface="${wgInterface.name}"`;
+
   const returnText = [
     '# HELP wg-easy and wireguard metrics',
     '',
     '# HELP wireguard_configured_peers',
     '# TYPE wireguard_configured_peers gauge',
-    `wireguard_configured_peers{interface="wg0"} ${wireguardPeerCount}`,
+    `wireguard_configured_peers{${id}} ${wireguardPeerCount}`,
     '',
     '# HELP wireguard_enabled_peers',
     '# TYPE wireguard_enabled_peers gauge',
-    `wireguard_enabled_peers{interface="wg0"} ${wireguardEnabledPeersCount}`,
+    `wireguard_enabled_peers{${id}} ${wireguardEnabledPeersCount}`,
     '',
     '# HELP wireguard_connected_peers',
     '# TYPE wireguard_connected_peers gauge',
-    `wireguard_connected_peers{interface="wg0"} ${wireguardConnectedPeersCount}`,
+    `wireguard_connected_peers{${id}} ${wireguardConnectedPeersCount}`,
     '',
     '# HELP wireguard_sent_bytes Bytes sent to the peer',
     '# TYPE wireguard_sent_bytes counter',

--- a/src/server/utils/WireGuard.ts
+++ b/src/server/utils/WireGuard.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import debug from 'debug';
 import QRCode from 'qrcode';
 import type { ID } from '#db/schema';
+import type { InterfaceType } from '#db/repositories/interface/types';
 
 const WG_DEBUG = debug('WireGuard');
 
@@ -10,21 +11,17 @@ class WireGuard {
    * Save and sync config
    */
   async saveConfig() {
-    await this.#saveWireguardConfig('wg0');
-    await this.#syncWireguardConfig('wg0');
+    const wgInterface = await Database.interfaces.get();
+    await this.#saveWireguardConfig(wgInterface);
+    await this.#syncWireguardConfig(wgInterface);
   }
 
   /**
-   * Generates and saves WireGuard config from database as wg0
+   * Generates and saves WireGuard config from database
    */
-  async #saveWireguardConfig(infName: string) {
-    const wgInterface = await Database.interfaces.get(infName);
+  async #saveWireguardConfig(wgInterface: InterfaceType) {
     const clients = await Database.clients.getAll();
-    const hooks = await Database.hooks.get(infName);
-
-    if (!wgInterface || !hooks) {
-      throw new Error('Interface or Hooks not found');
-    }
+    const hooks = await Database.hooks.get();
 
     const result = [];
     result.push(wg.generateServerInterface(wgInterface, hooks));
@@ -37,19 +34,24 @@ class WireGuard {
     }
 
     WG_DEBUG('Saving Config...');
-    await fs.writeFile(`/etc/wireguard/${infName}.conf`, result.join('\n\n'), {
-      mode: 0o600,
-    });
+    await fs.writeFile(
+      `/etc/wireguard/${wgInterface.name}.conf`,
+      result.join('\n\n'),
+      {
+        mode: 0o600,
+      }
+    );
     WG_DEBUG('Config saved successfully.');
   }
 
-  async #syncWireguardConfig(infName: string) {
+  async #syncWireguardConfig(wgInterface: InterfaceType) {
     WG_DEBUG('Syncing Config...');
-    await wg.sync(infName);
+    await wg.sync(wgInterface.name);
     WG_DEBUG('Config synced successfully.');
   }
 
   async getClients() {
+    const wgInterface = await Database.interfaces.get();
     const dbClients = await Database.clients.getAll();
     const clients = dbClients.map((client) => ({
       ...client,
@@ -60,7 +62,7 @@ class WireGuard {
     }));
 
     // Loop WireGuard status
-    const dump = await wg.dump('wg0');
+    const dump = await wg.dump(wgInterface.name);
     dump.forEach(
       ({ publicKey, latestHandshakeAt, endpoint, transferRx, transferTx }) => {
         const client = clients.find((client) => client.publicKey === publicKey);
@@ -79,12 +81,8 @@ class WireGuard {
   }
 
   async getClientConfiguration({ clientId }: { clientId: ID }) {
-    const wgInterface = await Database.interfaces.get('wg0');
-    const userConfig = await Database.userConfigs.get('wg0');
-
-    if (!wgInterface || !userConfig) {
-      throw new Error('Interface or UserConfig not found');
-    }
+    const wgInterface = await Database.interfaces.get();
+    const userConfig = await Database.userConfigs.get();
 
     const client = await Database.clients.get(clientId);
 
@@ -124,47 +122,39 @@ class WireGuard {
 
   async Startup() {
     WG_DEBUG('Starting WireGuard...');
-    const wgInterfaces = await Database.interfaces.getAll();
-    for (const wgInterface of wgInterfaces) {
-      if (wgInterface.enabled !== true) {
-        continue;
-      }
-      // default interface has no keys
-      if (
-        wgInterface.privateKey === '---default---' &&
-        wgInterface.publicKey === '---default---'
-      ) {
-        WG_DEBUG('Generating new Wireguard Keys...');
-        const privateKey = await wg.generatePrivateKey();
-        const publicKey = await wg.getPublicKey(privateKey);
+    const wgInterface = await Database.interfaces.get();
 
-        await Database.interfaces.updateKeyPair(
-          wgInterface.name,
-          privateKey,
-          publicKey
-        );
-        WG_DEBUG('New Wireguard Keys generated successfully.');
-      }
-      WG_DEBUG(`Starting Wireguard Interface ${wgInterface.name}...`);
-      await this.#saveWireguardConfig(wgInterface.name);
-      await wg.down(wgInterface.name).catch(() => {});
-      await wg.up(wgInterface.name).catch((err) => {
-        if (
-          err &&
-          err.message &&
-          err.message.includes(`Cannot find device "${wgInterface.name}"`)
-        ) {
-          throw new Error(
-            `WireGuard exited with the error: Cannot find device "${wgInterface.name}"\nThis usually means that your host's kernel does not support WireGuard!`,
-            { cause: err.message }
-          );
-        }
+    // default interface has no keys
+    if (
+      wgInterface.privateKey === '---default---' &&
+      wgInterface.publicKey === '---default---'
+    ) {
+      WG_DEBUG('Generating new Wireguard Keys...');
+      const privateKey = await wg.generatePrivateKey();
+      const publicKey = await wg.getPublicKey(privateKey);
 
-        throw err;
-      });
-      await this.#syncWireguardConfig(wgInterface.name);
-      WG_DEBUG(`Wireguard Interface ${wgInterface.name} started successfully.`);
+      await Database.interfaces.updateKeyPair(privateKey, publicKey);
+      WG_DEBUG('New Wireguard Keys generated successfully.');
     }
+    WG_DEBUG(`Starting Wireguard Interface ${wgInterface.name}...`);
+    await this.#saveWireguardConfig(wgInterface);
+    await wg.down(wgInterface.name).catch(() => {});
+    await wg.up(wgInterface.name).catch((err) => {
+      if (
+        err &&
+        err.message &&
+        err.message.includes(`Cannot find device "${wgInterface.name}"`)
+      ) {
+        throw new Error(
+          `WireGuard exited with the error: Cannot find device "${wgInterface.name}"\nThis usually means that your host's kernel does not support WireGuard!`,
+          { cause: err.message }
+        );
+      }
+
+      throw err;
+    });
+    await this.#syncWireguardConfig(wgInterface);
+    WG_DEBUG(`Wireguard Interface ${wgInterface.name} started successfully.`);
 
     WG_DEBUG('Starting Cron Job...');
     await this.startCronJob();
@@ -184,10 +174,8 @@ class WireGuard {
 
   // Shutdown wireguard
   async Shutdown() {
-    const wgInterfaces = await Database.interfaces.getAll();
-    for (const wgInterface of wgInterfaces) {
-      await wg.down(wgInterface.name).catch(() => {});
-    }
+    const wgInterface = await Database.interfaces.get();
+    await wg.down(wgInterface.name).catch(() => {});
   }
 
   async cronJob() {

--- a/src/server/utils/WireGuard.ts
+++ b/src/server/utils/WireGuard.ts
@@ -18,6 +18,8 @@ class WireGuard {
 
   /**
    * Generates and saves WireGuard config from database
+   *
+   * Make sure to pass an updated InterfaceType object
    */
   async #saveWireguardConfig(wgInterface: InterfaceType) {
     const clients = await Database.clients.getAll();
@@ -122,7 +124,8 @@ class WireGuard {
 
   async Startup() {
     WG_DEBUG('Starting WireGuard...');
-    const wgInterface = await Database.interfaces.get();
+    // let as it has to refetch if keys change
+    let wgInterface = await Database.interfaces.get();
 
     // default interface has no keys
     if (
@@ -134,6 +137,7 @@ class WireGuard {
       const publicKey = await wg.getPublicKey(privateKey);
 
       await Database.interfaces.updateKeyPair(privateKey, publicKey);
+      wgInterface = await Database.interfaces.get();
       WG_DEBUG('New Wireguard Keys generated successfully.');
     }
     WG_DEBUG(`Starting Wireguard Interface ${wgInterface.name}...`);


### PR DESCRIPTION
## Description

This streamlines multi interface support.

The only reference to the default `wg0` interface is in the database layer.

renamed database to `wg-easy.db` as its not only about the `wg0` interface anymore

## Motivation

Currently the reference the wg0 was all over the place, as I started adding multi interface support but I don't think it makes sense. wg-easy is shifting towards the user. So the admin can just hand out accounts and the user can do everything themselves.
But now the user would download a client and wonder why it can't properly communicate with the other client (as its on another interface) or the user has to choose which interface to create/download a client from. but why would he know what that even means.
