### PR TITLE
Feature: added multiple allowed IPs support via wg0.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The Web UI will now be available on `http://0.0.0.0:51821`.
 
 The Prometheus metrics will now be available on `http://0.0.0.0:51821/metrics`. Grafana dashboard [21733](https://grafana.com/grafana/dashboards/21733-wireguard/)
 
-> 💡 Your configuration files will be saved in `~/.wg-easy`
+> 💡 Your configuration files will be saved in `~/.wg-easy`. You can modify `wg0.json` file for per client configuration. `extraAllowedIPs` and `serverPeerAllowedIPs` can be used for multi-network/gateway support
 
 WireGuard Easy can be launched with Docker Compose as well - just download
 [`docker-compose.yml`](docker-compose.yml), make necessary adjustments and


### PR DESCRIPTION
I've added `extraAllowedIPs` and `serverPeerAllowedIPs` props to the wg0.json config file. Using those, we can manually create custom routing through multi subnets for the tunnel. Previously, it was not possible. If people are interested, I will try to add feature for configuring through web GUI

## Description
By default, we cannot assign routing for multiple subnet IPs in a tunnel via wg0.json or web GUI. I have added 2 extra properties in the json named `extraAllowedIPs` and `serverPeerAllowedIPs`. `extraAllowedIPs` adds per client extra allowed IPs which will be routed through the tunnel. `serverPeerAllowedIPs` enables server to route allowed IP traffics to the peer (i.e. client). After which, restart the docker instance by running `docker restart wg-easy` (replace wg-easy with your instance name) and afterwards keep using as it used to be.

## Motivation and Context
This change enhances the routing for multi subnet IPs without typing commands manually everytime.
[Similar Feature Request](https://github.com/wg-easy/wg-easy/issues/1559)

## How has this been tested?
1. I've first tested keeping the variables blank for backwards compatibility. It works as undefined variables are handled in the code.
2. I've tested by using my home router subnet (eg. 192.168.68.0/24) in the serverPeerAllowedIPs in one peer (i.e. client `home_gateway`), extraAllowedIPs in all other clients. That has let me access all of my devices in that subnet securely though the tunnel. No need for adding a billion peers manually.

This test has been run through directly modifying `wg.json` via `docker exec` and also from the host machine. Both works.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/67fc5eda-bc51-44a6-9aac-713a32ee91ae)
![image](https://github.com/user-attachments/assets/b50bc217-ed7a-47d3-8ac7-af52074aec4c)
![image](https://github.com/user-attachments/assets/8b0bd4d9-37b9-4195-b6a2-c96f8e1d0940)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
