### PR TITLE
fixed Dockerfile HEALTHCHECK syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN npm ci --omit=dev &&\
 # Copy build result to a new image.
 # This saves a lot of disk space.
 FROM docker.io/library/node:lts-alpine
-HEALTHCHECK CMD /usr/bin/timeout 5s /bin/sh -c "/usr/bin/wg show | /bin/grep -q interface || exit 1" --interval=1m --timeout=5s --retries=3
+HEALTHCHECK --interval=1m --timeout=5s --retries=3 CMD /usr/bin/timeout 5s /bin/sh -c "/usr/bin/wg show | /bin/grep -q interface || exit 1"
 COPY --from=build_node_modules /app /app
 
 # Move node_modules one directory up, so during development


### PR DESCRIPTION
HEALTHCHECK options should always come before the CMD instruction

https://docs.docker.com/reference/dockerfile/#healthcheck