### PR TITLE
fixed Dockerfile HEALTHCHECK syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN find ./node_modules/@libsql -mindepth 1 -maxdepth 1 -type l ! -name 'linux*'
 FROM docker.io/library/node:lts-alpine
 WORKDIR /app
 
-HEALTHCHECK CMD /usr/bin/timeout 5s /bin/sh -c "/usr/bin/wg show | /bin/grep -q interface || exit 1" --interval=1m --timeout=5s --retries=3
+HEALTHCHECK --interval=1m --timeout=5s --retries=3 CMD /usr/bin/timeout 5s /bin/sh -c "/usr/bin/wg show | /bin/grep -q interface || exit 1"
 
 # Copy build
 COPY --from=build /app/.output /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,7 +6,7 @@ RUN npm install --global corepack@latest
 # Install pnpm
 RUN corepack enable pnpm
 
-HEALTHCHECK CMD /usr/bin/timeout 5s /bin/sh -c "/usr/bin/wg show | /bin/grep -q interface || exit 1" --interval=1m --timeout=5s --retries=3
+HEALTHCHECK --interval=1m --timeout=5s --retries=3 CMD /usr/bin/timeout 5s /bin/sh -c "/usr/bin/wg show | /bin/grep -q interface || exit 1"
 
 # Install Linux packages
 RUN apk add --no-cache \


### PR DESCRIPTION
HEALTHCHECK options should always come before the CMD instruction

Now HEALTHCHECK options passed to CMD:
`docker inspect wgeasy`
```
            "Healthcheck": {
                "Test": [
                    "CMD-SHELL",
                    "/usr/bin/timeout 5s /bin/sh -c \"/usr/bin/wg show | /bin/grep -q interface || exit 1\" --interval=1m --timeout=5s --retries=3"
                ]
            },
```

docs:
https://docs.docker.com/reference/dockerfile/#healthcheck