### PR TITLE
Fix: Add ui port to template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This update is an entire rewrite to make it even easier to set up your own VPN.
 - Deprecated Dockerless Installations
 - Added Docker Volume Mount (`/lib/modules`)
 - Removed ARMv6 and ARMv7 support
+- Connections over HTTP require setting the `INSECURE` env var
+- Changed license from CC BY-NC-SA 4.0 to AGPL-3.0-only
 
 ## [14.0.0] - 2024-09-04
 

--- a/docs/content/examples/tutorials/podman.md
+++ b/docs/content/examples/tutorials/podman.md
@@ -88,7 +88,7 @@ In the Admin Panel of your WireGuard server, go to the `Hooks` tab and add the f
 1. PostUp
 
    ```shell
-   apk add nftables; nft add table inet wg_table; nft add chain inet wg_table postrouting { type nat hook postrouting priority 100 \; }; nft add rule inet wg_table postrouting ip saddr {{ipv4Cidr}} oifname {{device}} masquerade; nft add rule inet wg_table postrouting ip6 saddr {{ipv6Cidr}} oifname {{device}} masquerade; nft add chain inet wg_table input { type filter hook input priority 0 \; policy drop \; }; nft add rule inet wg_table input udp dport {{port}} accept; nft add chain inet wg_table forward { type filter hook forward priority 0 \; policy drop \; }; nft add rule inet wg_table forward iifname "wg0" accept; nft add rule inet wg_table forward oifname "wg0" accept;
+   apk add nftables; nft add table inet wg_table; nft add chain inet wg_table postrouting { type nat hook postrouting priority 100 \; }; nft add rule inet wg_table postrouting ip saddr {{ipv4Cidr}} oifname {{device}} masquerade; nft add rule inet wg_table postrouting ip6 saddr {{ipv6Cidr}} oifname {{device}} masquerade; nft add chain inet wg_table input { type filter hook input priority 0 \; policy drop \; }; nft add rule inet wg_table input udp dport {{port}} accept; nft add rule inet wg_table input tcp dport {{uiPort}} accept; nft add chain inet wg_table forward { type filter hook forward priority 0 \; policy drop \; }; nft add rule inet wg_table forward iifname "wg0" accept; nft add rule inet wg_table forward oifname "wg0" accept;
    ```
 
 2. PostDown

--- a/src/server/utils/config.ts
+++ b/src/server/utils/config.ts
@@ -15,4 +15,16 @@ export const OLD_ENV = {
 export const WG_ENV = {
   /** UI is hosted on HTTP instead of HTTPS */
   INSECURE: process.env.INSECURE === 'true',
+  /** Port the UI is listening on */
+  PORT: assertEnv('PORT'),
 };
+
+function assertEnv<T extends string>(env: T) {
+  const val = process.env[env];
+
+  if (!val) {
+    throw new Error(`Missing environment variable: ${env}`);
+  }
+
+  return val;
+}

--- a/src/server/utils/template.ts
+++ b/src/server/utils/template.ts
@@ -15,6 +15,7 @@ export function template(templ: string, values: Record<string, string>) {
  * - ipv6Cidr: IPv6 CIDR
  * - device: Network device
  * - port: Port number
+ * - uiPort: UI port number
  */
 export function iptablesTemplate(templ: string, wgInterface: InterfaceType) {
   return template(templ, {
@@ -22,5 +23,6 @@ export function iptablesTemplate(templ: string, wgInterface: InterfaceType) {
     ipv6Cidr: wgInterface.ipv6Cidr,
     device: wgInterface.device,
     port: wgInterface.port.toString(),
+    uiPort: WG_ENV.PORT,
   });
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds the UI port to the hooks template

## Motivation
The recommended nftables rules are more strict and therefore need the ability to allow the ui port

Closes https://github.com/wg-easy/wg-easy/pull/1734 to allow creating a `:development` tag
