### PR TITLE
Fix: button triggering form

### DIFF
--- a/src/app/components/Base/Tooltip.vue
+++ b/src/app/components/Base/Tooltip.vue
@@ -5,7 +5,7 @@
         class="mx-2 inline-flex h-4 w-4 items-center justify-center rounded-full text-gray-400 outline-none focus:shadow-sm focus:shadow-black"
         as-child
       >
-        <button @click="open = !open">
+        <button type="button" @click="open = !open">
           <slot />
         </button>
       </TooltipTrigger>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

buttons by default have type submit, which is a problem in a form where the button is meant to open a tooltip