### PR TITLE
Fix: sync / rekey issue

### DIFF
--- a/src/server/utils/WireGuard.ts
+++ b/src/server/utils/WireGuard.ts
@@ -201,6 +201,7 @@ class WireGuard {
 
   async cronJob() {
     const clients = await Database.clients.getAll();
+    let needsSave = false;
     // Expires Feature
     for (const client of clients) {
       if (client.enabled !== true) continue;
@@ -210,6 +211,7 @@ class WireGuard {
       ) {
         WG_DEBUG(`Client ${client.id} expired.`);
         await Database.clients.toggle(client.id, false);
+        needsSave = true;
       }
     }
     // One Time Link Feature
@@ -220,10 +222,13 @@ class WireGuard {
       ) {
         WG_DEBUG(`OneTimeLink for Client ${client.id} expired.`);
         await Database.oneTimeLinks.delete(client.id);
+        // otl does not need wireguard sync
       }
     }
 
-    await this.saveConfig();
+    if (needsSave) {
+      await this.saveConfig();
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes #1786 

Not a sync does not happen every minute but only if a save is actually needed. in this case if a client is expired.
