### PR TITLE
Add option to disable ipv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ ENV PORT=51821
 ENV HOST=0.0.0.0
 ENV INSECURE=false
 ENV INIT_ENABLED=false
+ENV DISABLE_IPV6=false
 
 LABEL org.opencontainers.image.source=https://github.com/wg-easy/wg-easy
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -28,6 +28,7 @@ ENV PORT=51821
 ENV HOST=0.0.0.0
 ENV INSECURE=true
 ENV INIT_ENABLED=false
+ENV DISABLE_IPV6=false
 
 # Install Dependencies
 COPY src/package.json src/pnpm-lock.yaml ./

--- a/docs/content/advanced/config/optional-config.md
+++ b/docs/content/advanced/config/optional-config.md
@@ -4,8 +4,17 @@ title: Optional Configuration
 
 You can set these environment variables to configure the container. They are not required, but can be useful in some cases.
 
-| Env        | Default   | Example     | Description                    |
-| ---------- | --------- | ----------- | ------------------------------ |
-| `PORT`     | `51821`   | `6789`      | TCP port for Web UI.           |
-| `HOST`     | `0.0.0.0` | `localhost` | IP address web UI binds to.    |
-| `INSECURE` | `false`   | `true`      | If access over http is allowed |
+| Env            | Default   | Example     | Description                        |
+| -------------- | --------- | ----------- | ---------------------------------- |
+| `PORT`         | `51821`   | `6789`      | TCP port for Web UI.               |
+| `HOST`         | `0.0.0.0` | `localhost` | IP address web UI binds to.        |
+| `INSECURE`     | `false`   | `true`      | If access over http is allowed     |
+| `DISABLE_IPV6` | `false`   | `true`      | If IPv6 support should be disabled |
+
+/// note | IPv6 Caveats
+
+Disabling IPv6 will only disable the creation of the default IPv6 firewall rules. The clients will still get an IPv6 address assigned.
+
+This option can be removed in the future, as more devices support IPv6.
+
+///

--- a/src/server/utils/config.ts
+++ b/src/server/utils/config.ts
@@ -17,6 +17,8 @@ export const WG_ENV = {
   INSECURE: process.env.INSECURE === 'true',
   /** Port the UI is listening on */
   PORT: assertEnv('PORT'),
+  /** If IPv6 should be disabled */
+  DISABLE_IPV6: process.env.DISABLE_IPV6 === 'true',
 };
 
 export const WG_INITIAL_ENV = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds an option to disable IPv6.
This will only be documented in the docs, as this should only be used as a last resort.

## Motivation and Context

Many Synology users can't run v15


