### PR TITLE
Add custom site title feature with database migration

### DIFF
--- a/src/app/app.vue
+++ b/src/app/app.vue
@@ -19,6 +19,12 @@ toast.setToast(toastRef);
 // make sure to fetch release early
 useGlobalStore();
 
+// Fetch site title from general configuration with a key for refreshing
+const { data: generalConfig } = await useFetch('/api/admin/general', { key: 'site-title' });
+
+// Compute the title with fallback
+const siteTitle = computed(() => generalConfig.value?.siteTitle || 'WireGuard');
+
 useHead({
   bodyAttrs: {
     class: 'bg-gray-50 dark:bg-neutral-800',
@@ -52,6 +58,6 @@ useHead({
       content: 'black-translucent',
     },
   ],
-  title: 'WireGuard',
+  title: siteTitle,
 });
 </script>

--- a/src/app/pages/admin/general.vue
+++ b/src/app/pages/admin/general.vue
@@ -2,6 +2,14 @@
   <main v-if="data">
     <FormElement @submit.prevent="submit">
       <FormGroup>
+        <FormNullTextField
+          id="site-title"
+          v-model="data.siteTitle"
+          label="Site Title"
+          description="Custom title for browser tabs. Leave empty to use the default 'WireGuard' title."
+        />
+      </FormGroup>
+      <FormGroup>
         <FormNumberField
           id="session"
           v-model="data.sessionTimeout"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -137,6 +137,8 @@
   },
   "admin": {
     "general": {
+      "siteTitle": "Site Title",
+      "siteTitleDesc": "Custom title for the web interface",
       "sessionTimeout": "Session Timeout",
       "sessionTimeoutDesc": "Session duration for Remember Me (seconds)",
       "metrics": "Metrics",

--- a/src/server/database/migrations/0002_add_site_title.sql
+++ b/src/server/database/migrations/0002_add_site_title.sql
@@ -1,0 +1,1 @@
+ALTER TABLE general_table ADD COLUMN site_title text;

--- a/src/server/database/migrations/meta/_journal.json
+++ b/src/server/database/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1748427001203,
       "tag": "0001_classy_the_stranger",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1748427002000,
+      "tag": "0002_add_site_title",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/database/repositories/general/schema.ts
+++ b/src/server/database/repositories/general/schema.ts
@@ -12,6 +12,8 @@ export const general = sqliteTable('general_table', {
   metricsPrometheus: int('metrics_prometheus', { mode: 'boolean' }).notNull(),
   metricsJson: int('metrics_json', { mode: 'boolean' }).notNull(),
   metricsPassword: text('metrics_password'),
+  
+  siteTitle: text('site_title'),
 
   createdAt: text('created_at')
     .notNull()

--- a/src/server/database/repositories/general/service.ts
+++ b/src/server/database/repositories/general/service.ts
@@ -36,6 +36,7 @@ function createPreparedStatement(db: DBType) {
           metricsPrometheus: true,
           metricsJson: true,
           metricsPassword: true,
+          siteTitle: true,
         },
       })
       .prepare(),

--- a/src/server/database/repositories/general/types.ts
+++ b/src/server/database/repositories/general/types.ts
@@ -13,11 +13,17 @@ const metricsPassword = z
   .min(1, { message: t('zod.general.metricsPassword') })
   .nullable();
 
+const siteTitle = z
+  .string({ message: 'Site Title' })
+  .nullable();
+
+
 export const GeneralUpdateSchema = z.object({
   sessionTimeout: sessionTimeout,
   metricsPrometheus: metricsEnabled,
   metricsJson: metricsEnabled,
   metricsPassword: metricsPassword,
+  siteTitle: siteTitle,
 });
 
 export type GeneralUpdateType = z.infer<typeof GeneralUpdateSchema>;


### PR DESCRIPTION
This PR adds the ability to customize the site title from the Admin Panel.

Changes:
- Added a `siteTitle` field to the General table schema
- Created a migration file to add the column to existing databases
- Added a text input field in the Admin Panel settings
- Updated the app.vue to use the custom title with a fallback to "WireGuard"
- Fixed data refresh logic for reactive updates

This enhancement allows administrators to customize the browser tab title for their WireGuard Easy installation.