### PR TITLE
Updated container launch commands

### DIFF
--- a/docs/content/advanced/migrate/from-14-to-15.md
+++ b/docs/content/advanced/migrate/from-14-to-15.md
@@ -34,10 +34,10 @@ If you are using `docker run`
 docker stop wg-easy
 ```
 
-If you are using `docker-compose`
+If you are using `docker compose`
 
 ```shell
-docker-compose down
+docker compose down
 ```
 
 ### Start new container

--- a/docs/content/examples/tutorials/basic-installation.md
+++ b/docs/content/examples/tutorials/basic-installation.md
@@ -33,7 +33,7 @@ Follow the Docs here: <https://docs.docker.com/engine/install/> and install Dock
 
     ```shell
      cd /etc/docker/containers/wg-easy
-     sudo docker-compose up -d
+     sudo docker compose up -d
     ```
 
 ## Setup Firewall
@@ -56,8 +56,8 @@ To update `wg-easy` to the latest version, run:
 
 ```shell
 cd /etc/docker/containers/wg-easy
-sudo docker-compose pull
-sudo docker-compose up -d
+sudo docker compose pull
+sudo docker compose up -d
 ```
 
 ## Auto Update

--- a/docs/content/examples/tutorials/caddy.md
+++ b/docs/content/examples/tutorials/caddy.md
@@ -67,7 +67,7 @@ wg-easy.example.com {
 ...and start it with:
 
 ```shell
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 ## Adapt the docker composition of `wg-easy`
@@ -96,7 +96,7 @@ networks:
 ...and restart it with:
 
 ```shell
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 You can now access `wg-easy` at [https://wg-easy.example.com](https://wg-easy.example.com) and start the setup.

--- a/docs/content/examples/tutorials/traefik.md
+++ b/docs/content/examples/tutorials/traefik.md
@@ -141,7 +141,7 @@ sudo docker network create traefik
 ## Start traefik
 
 ```shell
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 You can no access the Traefik dashboard at `https://traefik.$example.com$` with the credentials you set in `traefik_dynamic.yml`.
@@ -178,7 +178,7 @@ networks:
 
 ```shell
 cd /etc/docker/containers/wg-easy
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 You can now access `wg-easy` at `https://wg-easy.$example.com$` and start the setup.


### PR DESCRIPTION
Replaced `docker-compose` with `docker compose` for compatibility with Compose V2

## Description
Replaced usage of `docker-compose` CLI with `docker compose`, which is now the officially recommended and supported method starting from Docker Compose V2. This change affects all places where `docker-compose` was used in scripts, documentation, or instructions.


## Motivation and Context
This change ensures compatibility with modern Docker setups, where `docker-compose` (the standalone Python binary) is deprecated and no longer pre-installed. Using `docker compose` (integrated plugin) avoids dependency issues and aligns with current Docker best practices. Using the command may cause a `docker-compose: command not found` error when using newer versions.

## How has this been tested?
Manually tested `docker compose up -d` in a local development environment running Docker Engine v24+ with Compose plugin installed. Verified that services started correctly and no regression occurred in container behavior.


## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
