### PR TITLE
Updated traefik documentation

### DIFF
--- a/docs/content/examples/tutorials/traefik.md
+++ b/docs/content/examples/tutorials/traefik.md
@@ -166,6 +166,7 @@ services:
       - "traefik.http.routers.wg-easy.entrypoints=websecure"
       - "traefik.http.routers.wg-easy.service=wg-easy"
       - "traefik.http.services.wg-easy.loadbalancer.server.port=51821"
+      - "traefik.docker.network=traefik"
     ...
 
 networks:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated the wg-easy docker compose file when using traefik. Added the "traefik.docker.network" label, this fixes a bug where the dashboard was not available because 2 network are assigned to the wg-easy docker compose file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without defining what network traefik has to use, it chooses one randomly which may result in the dashboard not being available.

From traefik documentation: "If a container is linked to several networks, be sure to set the proper network name, otherwise it will randomly pick one." [traefic docs](https://doc.traefik.io/traefik/reference/routing-configuration/other-providers/docker/#traefikdockernetwork)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I am running my wg-easy on my own home lab and ran into this issue myself.  Multiple services had the same problem that disappeared when adding the docker network label.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (no code)
- [x] My change requires a change to the documentation. (It is in the documentation)
- [x] I have updated the documentation accordingly.
