### PR TITLE
feat: make api more secure

### DIFF
--- a/src/server/utils/WireGuard.ts
+++ b/src/server/utils/WireGuard.ts
@@ -95,7 +95,7 @@ class WireGuard {
 
   async getAllClients() {
     const wgInterface = await Database.interfaces.get();
-    const dbClients = await Database.clients.getAll();
+    const dbClients = await Database.clients.getAllPublic();
     const clients = dbClients.map((client) => ({
       ...client,
       latestHandshakeAt: null as Date | null,

--- a/src/shared/utils/permissions.ts
+++ b/src/shared/utils/permissions.ts
@@ -59,7 +59,7 @@ type RolesWithPermissions = {
 
 export type Permissions = {
   clients: {
-    dataType: ClientType;
+    dataType: Pick<ClientType, 'id' | 'userId'>;
     action: 'view' | 'create' | 'update' | 'delete' | 'custom';
   };
   admin: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The api wont return private and preshared key for /api/client anymore.

It will still do it for /api/client/{clientId}

This is to make wg-easy a bit more secure, as the mentioned endpoint is called every second

this is technically a breaking change, but because of https://wg-easy.github.io/wg-easy/v15.1/advanced/api/ ok in this case