### PR TITLE
Fixes network creation in docker-run.md

### DIFF
--- a/docs/content/examples/tutorials/docker-run.md
+++ b/docs/content/examples/tutorials/docker-run.md
@@ -8,7 +8,8 @@ To setup the IPv6 Network, simply run once:
 docker network create \
   -d bridge --ipv6 \
   --subnet 10.42.42.0/24 \
-  --subnet fdcc:ad94:bacf:61a3::/64 wg
+  --subnet fdcc:ad94:bacf:61a3::/64 \
+   wg
 ```
 
 <!-- ref: major version -->


### PR DESCRIPTION
## Description
Fixes network creation in docker-run.md

## Motivation and Context
The current command doesn't work

## How has this been tested?
On Ubuntu with 24.04 with Docker desktop installed

## Types of changes
- [x] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

