### PR TITLE
Add interface_name to the wg network in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     container_name: wg-easy
     networks:
       wg:
+        interface_name: eth0
         ipv4_address: 10.42.42.42
         ipv6_address: fdcc:ad94:bacf:61a3::2a
     volumes:


### PR DESCRIPTION
Added `interface_name: eth0` to the `wg` network in the example docker-compose.yml

<!--- Provide a general summary of your changes in the Title above -->

## Description
When using multiple networks (like with Traefik or caddy-docker-proxy), the interface name keeps changing after a container restart, sometimes preventing the VPN from working. Adding an explicit name for the main `wg` network prevents them from switching with other networks (ie: going from `eth0` to `eth1` and vice versa)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I was having issues with my current wg-easy setup, sometimes preventing any network traffic through the VPN but still successfully connecting.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

 I tested my setup without using caddy-docker-proxy, and had no issues. With multiple networks, running `docker exec wg-easy ip a` shows both networks under `eth0` and `eth1`, with them swapping sometimes after a container restart. With the changes to my compose.yaml, running the above command now shows the `wg` network always on `eth0`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. (Maybe, works by default but might be good to mention under the reverse proxy setups)
- [ ] I have updated the documentation accordingly.
