### PR TITLE
Feat: Allow empty dns

### DIFF
--- a/src/server/utils/types.ts
+++ b/src/server/utils/types.ts
@@ -80,7 +80,6 @@ export function validateZod<T>(
             if (t) {
               let newMessage = null;
               if (v.message.startsWith('zod.')) {
-                console.log(v);
                 switch (v.code) {
                   case 'too_small':
                     switch (v.origin) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR allows to have no DNS in the User Config

But: You cannot set no DNS for only one Device. As this would conflict with the fallback behavior to the global config

Note: this will result in an empty dns field. `DNS = `. But this seems to work in the official wireguard clients

## Motivation and Context

Closes #1907 

## How has this been tested?

Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
