### PR TITLE
Add routed (no NAT) example setup

### DIFF
--- a/docs/content/examples/tutorials/routed.md
+++ b/docs/content/examples/tutorials/routed.md
@@ -2,7 +2,7 @@
 title: Routed setup (No NAT)
 ---
 
-This guide shows how to run **wg-easy** with a routed setup so packets are forwarded instead of NATed.
+This guide shows how to run **wg-easy** with a routed setup, so packets are forwarded instead of NATed.
 
 In a routed design, each WireGuard client keeps its own IPv4/IPv6 address. That means you can identify clients by their real addresses instead of seeing everything as the WireGuard server’s IP.
 
@@ -54,7 +54,7 @@ sysctl -n net.ipv4.ip_forward   # should print 1
 
 ## Add static routes on your router
 
-Pick an IPv4 and IPv6 subnet for your clients and add static routes on your router, pointing to the wireguard server's LAN addresses.
+Pick an IPv4 and IPv6 subnet for your clients and add static routes on your router, pointing to the WireGuard server's LAN addresses.
 
 ### Example
 
@@ -74,11 +74,11 @@ On your router:
 - Route `192.168.0.0/24` → next hop `192.168.10.118`
 - Route `2001:db8:abc:0::/64` → next hop `2001:db8:abc:10:216:3eff:fedb:949e`
 
-Don't forget to create the neccesary firewall rules to allow these subnets to travel across your LAN. Some routers like OPNSense/PFSense may require specific Outbound NAT rules for the chosen IPv4 subnet (And IPv6 if ULA).
+Don't forget to create the necessary firewall rules to allow these subnets to travel across your LAN. Some routers or servers may require specific Outbound NAT rules for the chosen IPv4 and IPv6 subnets to allow traffic to traverse your LAN.
 
-## Wireguard Easy configuration
+## `wg-easy` configuration
 
-In the web UI → Admin → Interface, click Change CIDR and set the IPv4/IPv6 routed subnets you chose above. Save.
+In the Web UI → Admin → Interface, click Change CIDR and set the IPv4/IPv6 routed subnets you chose above. Save.
 
 Then go to Admin → Hooks and add:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I've added an example to set up wg-easy with a no-NAT setup.

Fixes https://github.com/wg-easy/wg-easy/issues/2174

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

No NAT has several benefits!  You can identify your clients by their respective IP addresses instead of seeing all of your clients as your wireguard server's host IP.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
