### PR TITLE
Fix: Allow lower MTU

### DIFF
--- a/src/server/utils/types.ts
+++ b/src/server/utils/types.ts
@@ -22,7 +22,8 @@ export const EnabledSchema = z.boolean({ message: t('zod.enabled') });
 
 export const MtuSchema = z
   .number({ message: t('zod.mtu') })
-  .min(1280, { message: t('zod.mtu') })
+  // min for IPv6 is 1280, but we allow lower for IPv4
+  .min(1024, { message: t('zod.mtu') })
   .max(9000, { message: t('zod.mtu') });
 
 export const PortSchema = z


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For users only using IPv4 a lower MTU might be required. This PR allows that. But users using IPv6 should never go below 1280

## Motivation and Context

Closes #2210 

