### PR TITLE
add INIT_PASSWORD_FILE environment variable

### DIFF
--- a/docs/content/advanced/config/unattended-setup.md
+++ b/docs/content/advanced/config/unattended-setup.md
@@ -10,7 +10,7 @@ These will only be used during the first start of the container. After that, the
 | ------------------ | ---------------------------- | --------------------------------------------------------- | ----- |
 | `INIT_ENABLED`     | `true`                       | Enables the below env vars                                | 0     |
 | `INIT_USERNAME`    | `admin`                      | Sets admin username                                       | 1     |
-| `INIT_PASSWORD`    | `Se!ureP%ssw`                | Sets admin password                                       | 1     |
+| `INIT_PASSWORD`    | `Se!ureP%ssw`                | Sets admin password (or `INIT_PASSWORD_FILE`)             | 1     |
 | `INIT_HOST`        | `vpn.example.com`            | Host clients will connect to                              | 1     |
 | `INIT_PORT`        | `51820`                      | Port clients will connect to and wireguard will listen on | 1     |
 | `INIT_DNS`         | `1.1.1.1,8.8.8.8`            | Sets global dns setting                                   | 2     |

--- a/src/server/utils/config.ts
+++ b/src/server/utils/config.ts
@@ -1,5 +1,6 @@
 import debug from 'debug';
 import packageJson from '@@/package.json';
+import fs from 'fs';
 
 export const RELEASE = 'v' + packageJson.version;
 
@@ -31,10 +32,14 @@ export const WG_ENV = {
   EXPERIMENTAL_AWG: process.env.EXPERIMENTAL_AWG === 'true',
 };
 
+const PASSWORD = process.env.INIT_PASSWORD_FILE?.length > 0 ?
+  fs.readFileSync(process.env.INIT_PASSWORD_FILE, 'utf-8').trim() :
+  process.env.INIT_PASSWORD;
+
 export const WG_INITIAL_ENV = {
   ENABLED: process.env.INIT_ENABLED === 'true',
   USERNAME: process.env.INIT_USERNAME,
-  PASSWORD: process.env.INIT_PASSWORD,
+  PASSWORD,
   DNS: process.env.INIT_DNS?.split(',').map((x) => x.trim()),
   IPV4_CIDR: process.env.INIT_IPV4_CIDR,
   IPV6_CIDR: process.env.INIT_IPV6_CIDR,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the `INIT_PASSWORD_FILE` environment variable to read the password from a file during unattended setup. The `INIT_PASSWORD_FILE` variable takes precedence over the `INIT_PASSWORD` variable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Using secrets in Docker setup is preferred and more secure way of passing secrets to a runtime.
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
I have tested, that it reads provided file and fallback to `INIT_PASSWORD`. If read fails, it will throw an exception.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
