### PR TITLE
add filename cleaning at OneTimeLink download

### DIFF
--- a/src/server/api/client/[clientId]/configuration.get.ts
+++ b/src/server/api/client/[clientId]/configuration.get.ts
@@ -19,16 +19,11 @@ export default definePermissionEventHandler(
     }
 
     const config = await WireGuard.getClientConfiguration({ clientId });
-    const configName = client.name
-      .replace(/[^a-zA-Z0-9_=+.-]/g, '-')
-      .replace(/(-{2,}|-$)/g, '-')
-      .replace(/-$/, '')
-      .substring(0, 32);
 
     setHeader(
       event,
       'Content-Disposition',
-      `attachment; filename="${configName || clientId}.conf"`
+      `attachment; filename="${WireGuard.cleanClientFilename(client.name) || clientId}.conf"`
     );
 
     setHeader(event, 'Content-Type', 'text/plain');

--- a/src/server/routes/cnf/[oneTimeLink].ts
+++ b/src/server/routes/cnf/[oneTimeLink].ts
@@ -27,16 +27,10 @@ export default defineEventHandler(async (event) => {
   });
   await Database.oneTimeLinks.erase(otl.id);
 
-  const configName = client.name
-    .replace(/[^a-zA-Z0-9_=+.-]/g, '-')
-    .replace(/(-{2,}|-$)/g, '-')
-    .replace(/-$/, '')
-    .substring(0, 32);
-
   setHeader(
     event,
     'Content-Disposition',
-    `attachment; filename="${configName || client.id}.conf"`
+    `attachment; filename="${WireGuard.cleanClientFilename(client.name) || client.id}.conf"`
   );
   setHeader(event, 'Content-Type', 'text/plain');
   return config;

--- a/src/server/utils/WireGuard.ts
+++ b/src/server/utils/WireGuard.ts
@@ -170,6 +170,14 @@ class WireGuard {
     });
   }
 
+  cleanClientFilename(name: string): string {
+    return name
+      .replace(/[^a-zA-Z0-9_=+.-]/g, '-')
+      .replace(/(-{2,}|-$)/g, '-')
+      .replace(/-$/, '')
+      .substring(0, 32);
+  }
+
   async Startup() {
     WG_DEBUG('Starting WireGuard...');
     // let as it has to refetch if keys change


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improve OneTimeLink download: sanitize filenames and fix Content-Disposition encoding for non-ASCII characters

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Client names with non-ASCII characters caused Content-Disposition header errors during OneTimeLink downloads. This fix adds proper filename encoding to prevent download failures

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
