### PR TITLE
Feature: add search api

### DIFF
--- a/src/server/api/client/search.get.ts
+++ b/src/server/api/client/search.get.ts
@@ -1,0 +1,18 @@
+import { ClientQuerySchema } from '#db/repositories/client/types';
+
+export default definePermissionEventHandler(
+  'clients',
+  'custom',
+  async ({ event, user }) => {
+    const { filter } = await getValidatedQuery(
+      event,
+      validateZod(ClientQuerySchema, event)
+    );
+
+    // Filter is used to search by name, IPv4, or IPv6
+    if (user.role === roles.ADMIN) {
+      return WireGuard.getAllClients(filter);
+    }
+    return WireGuard.getClientsForUser(user.id, filter);
+  }
+);


### PR DESCRIPTION
The change proposes a new api to search for clients by name or ip address.

## Description
This is useful whenever new clients need to be dynamically added both on Caddy (or any other web server) and wg-easy for instance. In fact, one could:
- Create a new client on wg-easy via the api (providing a name)
- Fetch the wg-easy client via the proposed search api
- Find out which ip wg-easy assigned to the new peer
- Inject a new route to Caddy with the fetched peer IP Address

Also, it's generally useful for quickly searching peers using third party integrations.

It does not introduce a breaking change.

## Motivation and Context
It solves an issue I'm having with a custom integration: today, finding out which ip address has been assigned by wg-easy via the api means scanning the whole list of peers via the /api/client route, which is sub-optimal.

## How has this been tested?
Tested manually

## Screenshots (if appropriate):
Not applicable

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation. 
- [ ] I have updated the documentation accordingly. (note: documentation for API still needs to be properly written)
