### PR TITLE
fix(i18n): Add missing translation for delete action

### DIFF
--- a/src/app/pages/clients/[id].vue
+++ b/src/app/pages/clients/[id].vue
@@ -179,7 +179,7 @@
               @delete="deleteClient"
             >
               <FormSecondaryActionField
-                label="Delete"
+                :label="$t('client.delete')"
                 class="w-full"
                 type="button"
                 tabindex="-1"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -88,6 +88,7 @@
     "name": "Name",
     "expireDate": "Expire Date",
     "expireDateDesc": "Date the client will be disabled. Blank for permanent",
+    "delete": "Delete",
     "deleteClient": "Delete Client",
     "deleteDialog1": "Are you sure you want to delete",
     "deleteDialog2": "This action cannot be undone.",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -88,6 +88,7 @@
     "name": "名稱",
     "expireDate": "到期日",
     "expireDateDesc": "用戶端將被停用的日期。留白表示永久有效",
+    "delete": "刪除",
     "deleteClient": "刪除用戶端",
     "deleteDialog1": "您確定要刪除",
     "deleteDialog2": "此動作無法復原。",
@@ -117,7 +118,9 @@
     "notConnected": "用戶端未連線",
     "endpoint": "端點",
     "endpointDesc": "用戶端建立 WireGuard 連線的來源 IP",
-    "search": "搜尋用戶端..."
+    "search": "搜尋用戶端...",
+    "config": "組態設定",
+    "viewConfig": "檢視組態設定"
   },
   "dialog": {
     "change": "變更",
@@ -237,6 +240,12 @@
     "postUp": "PostUp",
     "preDown": "PreDown",
     "postDown": "PostDown"
+  },
+  "copy": {
+    "notSupported": "無法複製",
+    "copied": "已複製!",
+    "failed": "複製失敗",
+    "copy": "複製"
   },
   "awg": {
     "jCLabel": "填充封包數量 (Jc)",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a missing translation key for the delete action used in the client details page.  The hard-coded `Delete` label in the Vue component is replaced with a localized string reference.

Additionally, several new Traditional Chinese (zh-TW) translation entries are added, including items related to configuration viewing and copy-status messages.

## Motivation and Context
The UI previously displayed an untranslated `Delete` string when rendered in non-English locales.

## How has this been tested?
- Verified that the client details page now correctly shows the localized delete label.

## Screenshots (if appropriate):
<img width="600" src="https://github.com/user-attachments/assets/9a65ca9d-cbee-43e8-af7a-7632fe4c10b0" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
