### PR TITLE
Fix light mode admin menu active text color

### DIFF
--- a/src/app/pages/admin.vue
+++ b/src/app/pages/admin.vue
@@ -18,7 +18,7 @@
             >
               <BaseSecondaryButton
                 as="span"
-                class="w-full rounded p-2 font-medium transition-colors duration-200 hover:bg-red-800 group-[.active]:text-white dark:text-neutral-200"
+                class="w-full font-medium group-[.active]:text-white"
               >
                 {{ item.name }}
               </BaseSecondaryButton>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes the text color of the active menu item in the admin panel in light mode from black to white
Also changes the color in dark mode from neutral-200

## Motivation and Context
Fixes #2306 

## How has this been tested?
Locally

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
