### PR TITLE
feat: add automatic public IP refresh for dynamic IP users

### DIFF
--- a/src/server/utils/config.ts
+++ b/src/server/utils/config.ts
@@ -54,6 +54,15 @@ export const WG_INITIAL_ENV = {
     : undefined,
 };
 
+export const WG_AUTO_REFRESH_ENV = {
+  /** Enable automatic IP refresh when host was set to auto-detected IP */
+  ENABLED: process.env.SERVERURL_AUTO_REFRESH === 'true',
+  /** Interval in milliseconds between IP checks (default: 300000 = 5 minutes) */
+  INTERVAL: process.env.SERVERURL_AUTO_REFRESH_INTERVAL
+    ? Number.parseInt(process.env.SERVERURL_AUTO_REFRESH_INTERVAL, 10) * 1000
+    : 300 * 1000,
+};
+
 function assertEnv<T extends string>(env: T) {
   const val = process.env[env];
 

--- a/src/server/utils/ip.ts
+++ b/src/server/utils/ip.ts
@@ -170,3 +170,12 @@ async function getIpInformation() {
 export const cachedGetIpInformation = cacheFunction(getIpInformation, {
   expiry: 15 * 60 * 1000,
 });
+
+/**
+ * Get current public IPv4 address (non-cached)
+ * Used for auto-refresh feature
+ */
+export async function getCurrentPublicIpv4(): Promise<string | null> {
+  const ip = await getPublicIpv4();
+  return ip ?? null;
+}


### PR DESCRIPTION
## Summary

-   Adds optional automatic public IP refresh feature for users with dynamic IPs
-   When enabled, periodically checks if public IP has changed and updates the database
-   Fully backwards compatible, disabled by default

## Problem

When using wg-easy with `SERVERURL=auto`, the public IP is detected once during initial setup and stored in the database (`user_configs_table.host`). If the ISP assigns a new IP address, new client configurations are generated with the stale IP, making them unusable.

Current workarounds require manual database updates, external scripts with Docker command overrides or reinstalling wg-easy.

## Solution

Two new environment variables:

  ------------------------------------------------------------------------------------
  Variable                            Default             Description
  ----------------------------------- ------------------- ----------------------------
  `SERVERURL_AUTO_REFRESH`            `false`             Enable automatic IP refresh
  `SERVERURL_AUTO_REFRESH_INTERVAL`   `300`               Seconds between IP checks
  ------------------------------------------------------------------------------------

### How it works

1.  The existing `cronJob()` (runs every 60s) checks if auto refresh is enabled
2.  If enabled and the configured interval has passed, fetches current public IP via OpenDNS (same existing methodd)
3.  Compares it with the stored IP in the database
4.  If different, updates `user_configs_table.host`
5.  New client configs and QR codes automatically use the updated IP

### Usage

``` yaml
services:
  wg-easy:
    environment:
      - SERVERURL_AUTO_REFRESH=true
      - SERVERURL_AUTO_REFRESH_INTERVAL=300
```

## Changes

  ----------------------------------------------------------------------------
  File                              Changes
  --------------------------------- ------------------------------------------
  `src/server/utils/config.ts`      Added WG_AUTO_REFRESH_ENV configuration
  `src/server/utils/ip.ts`          Exported `getCurrentPublicIpv4()` function
  `src/server/utils/WireGuard.ts`   Added `checkAndUpdatePublicIp()` method and integration with `cronJob()`
  ----------------------------------------------------------------------------

## Test plan

-   Verify feature is disabled by default
-   Enable `SERVERURL_AUTO_REFRESH=true` and verify IP check every 5 min
-   Test with custom interval
-   Verify logs when IP changes: `Auto-refresh: IP changed from X to Y`
-   Verify new client configs use updated IP after change
-   Test behavior when IP detection fails (warning and continue)
