### PR TITLE
Fix healthcheck for amneziawg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add linux-headers build-base git && \
 FROM docker.io/library/node:jod-alpine
 WORKDIR /app
 
-HEALTHCHECK --interval=1m --timeout=5s --retries=3 CMD /usr/bin/timeout 5s /bin/sh -c "/usr/bin/wg show | /bin/grep -q interface || exit 1"
+HEALTHCHECK --interval=1m --timeout=5s --retries=3 CMD /usr/bin/timeout 5s /bin/sh -c "/usr/bin/wg show | /bin/grep -q interface || /usr/bin/awg show | /bin/grep -q interface || exit 1"
 
 # Copy build
 COPY --from=build /app/.output /app


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes healthcheck for awg

## Motivation and Context
Currently healthcheck for awg doesn't work, since wg command return nothing when awg interface is up

## How has this been tested?
> /usr/bin/awg show | /bin/grep -q interface
Works for me

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
