### PR TITLE
feat(docs): Extend docs for routed setup with nftables

### DIFF
--- a/docs/content/examples/tutorials/routed.md
+++ b/docs/content/examples/tutorials/routed.md
@@ -95,6 +95,7 @@ iptables -D INPUT -p udp -m udp --dport {{port}} -j ACCEPT; iptables -D FORWARD 
 ```
 
 /// warning | Important: When using nftables use the following hooks instead.
+
 PostUp
 
 ```shell


### PR DESCRIPTION
## Description
As described in #2350 a routed setup did not work when using nftables. This PR adds the necessary changes to the documentation describing how to setup postup and down hooks for nftables.

## Motivation and Context
When using nftables in a routed setup different up and down hooks need to be used.  To limit interaction with docker managed chains a custom WG_EASY chain is added as a jump target in the DOCKER-USER chain. 

Since nft only supports deletion via handles awk is needed to get the handle of the jump rule for deletion during PostDown. Unfortunately nft does not offer a different mechanism for this

## How has this been tested?
Tested locally 
<img width="963" height="746" alt="image" src="https://github.com/user-attachments/assets/8298b2a7-8979-4881-8adb-5c339915a1a6" />

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
