### PR TITLE
feat: add Amnezia check to Dockerfile healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN apk add linux-headers build-base git && \
 FROM docker.io/library/node:jod-alpine
 WORKDIR /app
 
-HEALTHCHECK --interval=1m --timeout=5s --retries=3 CMD /usr/bin/timeout 5s /bin/sh -c "/usr/bin/wg show | /bin/grep -q interface || exit 1"
+HEALTHCHECK --interval=1m --timeout=5s --retries=3 \
+  CMD /usr/bin/timeout 5s sh -c '/usr/bin/wg show 2>/dev/null | grep -q interface || /usr/bin/awg show 2>/dev/null | grep -q interface'
 
 # Copy build
 COPY --from=build /app/.output /app


### PR DESCRIPTION
## Description
This extends the Docker health check to check first if the WG interface is present and in a second step checks if the AWG interface is present. If none are found the check fails.
The '2>/dev/null' silences errors for the case that the AWG kernel module is not installed.

## Motivation and Context
When using the image with Amnezia my contianer constantly restarts. In Issue [2376](https://github.com/wg-easy/wg-easy/issues/2376) I got the recommendation on how to fix this temporarilly by adding a different healthcheck to my compose file.
This change adds this into the image directly.

## How has this been tested?
I wrote this check in compose files on different systems running:
- wireguard with amnezia kernel module
- wireguard without amnezia kernel module
- amnezia

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
