### PR TITLE
Fix: Add trailing newline to Prometheus metrics output

### DIFF
--- a/src/server/routes/metrics/prometheus.get.ts
+++ b/src/server/routes/metrics/prometheus.get.ts
@@ -62,6 +62,7 @@ async function getPrometheusResponse() {
     '# HELP wireguard_latest_handshake_seconds UNIX timestamp seconds of the last handshake',
     '# TYPE wireguard_latest_handshake_seconds gauge',
     `${wireguardLatestHandshakeSeconds.join('\n')}`,
+    '',
   ];
 
   return returnText.join('\n');


### PR DESCRIPTION
Fix: Add trailing newline to Prometheus metrics output

## Description
Add a trailing newline character (\n) at the end of the Prometheus metrics output.

## Motivation and Context
Unified Agent (Yandex Cloud Monitoring) fails to parse metrics from wg-easy with the following error:
```txt
wireguard_configured_peers[truncated][size 8788]], error [(NMonitoring::TPrometheusDecodeException) library/cpp/monlib/encode/prometheus/prometheus_decoder.cpp:213: unexpected error (TFromStringException) util/string/cast.cpp:264: Cannot parse empty string as number.  at line #74], message rejected
# TYPE wireguard_configured_peers gauge
2026-04-11T20:03:45.009913Z 1 11964175148092859060 ERROR agent/input-metrics_pull error parsing [prometheus], meta [(empty)], payload [# HELP wireguard_configured_peers
```

## How has this been tested?
Verified that Unified Agent (Yandex Cloud Monitoring) successfully parses and ingests metrics after the fix, with no more TPrometheusDecodeException errors in the agent log.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
