### PR TITLE
add WG_INTERFACE env var to support multiple instances on the same host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ ENV HOST=0.0.0.0
 ENV INSECURE=false
 ENV INIT_ENABLED=false
 ENV DISABLE_IPV6=false
+ENV WG_INTERFACE=wg0
 
 LABEL org.opencontainers.image.source=https://github.com/wg-easy/wg-easy
 

--- a/docs/content/advanced/config/optional-config.md
+++ b/docs/content/advanced/config/optional-config.md
@@ -4,12 +4,13 @@ title: Optional Configuration
 
 You can set these environment variables to configure the container. They are not required, but can be useful in some cases.
 
-| Env            | Default   | Example     | Description                        |
-| -------------- | --------- | ----------- | ---------------------------------- |
-| `PORT`         | `51821`   | `6789`      | TCP port for Web UI.               |
-| `HOST`         | `0.0.0.0` | `localhost` | IP address web UI binds to.        |
-| `INSECURE`     | `false`   | `true`      | If access over http is allowed     |
-| `DISABLE_IPV6` | `false`   | `true`      | If IPv6 support should be disabled |
+| Env            | Default   | Example     | Description                                                                                                                 |
+| -------------- | --------- | ----------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`         | `51821`   | `6789`      | TCP port for Web UI.                                                                                                        |
+| `HOST`         | `0.0.0.0` | `localhost` | IP address web UI binds to.                                                                                                 |
+| `INSECURE`     | `false`   | `true`      | If access over http is allowed                                                                                              |
+| `DISABLE_IPV6` | `false`   | `true`      | If IPv6 support should be disabled                                                                                          |
+| `WG_INTERFACE` | `wg0`     | `wg1`       | WireGuard interface name. Change when running multiple instances on the same host (e.g. `hostNetwork: true` in Kubernetes). |
 
 /// note | IPv6 Caveats
 

--- a/docs/content/advanced/config/optional-config.md
+++ b/docs/content/advanced/config/optional-config.md
@@ -4,13 +4,13 @@ title: Optional Configuration
 
 You can set these environment variables to configure the container. They are not required, but can be useful in some cases.
 
-| Env            | Default   | Example     | Description                                                                                                                 |
-| -------------- | --------- | ----------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`         | `51821`   | `6789`      | TCP port for Web UI.                                                                                                        |
-| `HOST`         | `0.0.0.0` | `localhost` | IP address web UI binds to.                                                                                                 |
-| `INSECURE`     | `false`   | `true`      | If access over http is allowed                                                                                              |
-| `DISABLE_IPV6` | `false`   | `true`      | If IPv6 support should be disabled                                                                                          |
-| `WG_INTERFACE` | `wg0`     | `wg1`       | WireGuard interface name. Change when running multiple instances on the same host (e.g. `hostNetwork: true` in Kubernetes). |
+| Env            | Default   | Example     | Description                                                                        |
+| -------------- | --------- | ----------- | ---------------------------------------------------------------------------------- |
+| `PORT`         | `51821`   | `6789`      | TCP port for Web UI.                                                               |
+| `HOST`         | `0.0.0.0` | `localhost` | IP address web UI binds to.                                                        |
+| `INSECURE`     | `false`   | `true`      | If access over http is allowed                                                     |
+| `DISABLE_IPV6` | `false`   | `true`      | If IPv6 support should be disabled                                                 |
+| `WG_INTERFACE` | `wg0`     | `wg1`       | WireGuard interface name. Change when running multiple instances on the same host. |
 
 /// note | IPv6 Caveats
 

--- a/src/server/database/sqlite.ts
+++ b/src/server/database/sqlite.ts
@@ -20,6 +20,7 @@ const db = drizzle({ client, schema });
 
 export async function connect() {
   await migrate();
+  await normalizeInterfaceName(db);
   const dbService = new DBService(db);
 
   if (WG_INITIAL_ENV.ENABLED) {
@@ -120,12 +121,46 @@ async function initialSetup(db: DBServiceType) {
   }
 }
 
+/**
+ * Replaces hardcoded 'wg0' in the stored iptables hook commands with the
+ * actual WG_INTERFACE name. Runs after migration so fresh installs that use a
+ * non-default interface (e.g. wg1) get the correct interface name in their
+ * PostUp/PostDown rules. Idempotent when WG_INTERFACE=wg0.
+ */
+async function normalizeInterfaceName(db: DBType) {
+  const iface = WG_ENV.WG_INTERFACE;
+  if (iface === 'wg0') return;
+
+  DB_DEBUG(`Normalizing interface name 'wg0' -> '${iface}' in hooks...`);
+
+  await db.transaction(async (tx) => {
+    const hooks = await tx.query.hooks
+      .findFirst({ where: eq(schema.hooks.id, 'wg0') });
+
+    if (!hooks) return;
+
+    const needsUpdate =
+      hooks.postUp.includes('wg0') || hooks.postDown.includes('wg0');
+
+    if (needsUpdate) {
+      await tx
+        .update(schema.hooks)
+        .set({
+          postUp: hooks.postUp.replaceAll('wg0', iface),
+          postDown: hooks.postDown.replaceAll('wg0', iface),
+        })
+        .where(eq(schema.hooks.id, 'wg0'))
+        .execute();
+      DB_DEBUG(`Interface name normalized to '${iface}' in hooks.`);
+    }
+  });
+}
+
 async function disableIpv6(db: DBType) {
-  // This should match the initial value migration
-  const postUpMatch =
-    ' ip6tables -t nat -A POSTROUTING -s {{ipv6Cidr}} -o {{device}} -j MASQUERADE; ip6tables -A INPUT -p udp -m udp --dport {{port}} -j ACCEPT; ip6tables -A FORWARD -i wg0 -j ACCEPT; ip6tables -A FORWARD -o wg0 -j ACCEPT;';
-  const postDownMatch =
-    ' ip6tables -t nat -D POSTROUTING -s {{ipv6Cidr}} -o {{device}} -j MASQUERADE; ip6tables -D INPUT -p udp -m udp --dport {{port}} -j ACCEPT; ip6tables -D FORWARD -i wg0 -j ACCEPT; ip6tables -D FORWARD -o wg0 -j ACCEPT;';
+  const iface = WG_ENV.WG_INTERFACE;
+  // This should match the initial value migration (after normalizeInterfaceName runs)
+  const postUpMatch = ` ip6tables -t nat -A POSTROUTING -s {{ipv6Cidr}} -o {{device}} -j MASQUERADE; ip6tables -A INPUT -p udp -m udp --dport {{port}} -j ACCEPT; ip6tables -A FORWARD -i ${iface} -j ACCEPT; ip6tables -A FORWARD -o ${iface} -j ACCEPT;`;
+  const postDownMatch = ` ip6tables -t nat -D POSTROUTING -s {{ipv6Cidr}} -o {{device}} -j MASQUERADE; ip6tables -D INPUT -p udp -m udp --dport {{port}} -j ACCEPT; ip6tables -D FORWARD -i ${iface} -j ACCEPT; ip6tables -D FORWARD -o ${iface} -j ACCEPT;`;
 
   await db.transaction(async (tx) => {
     const hooks = await tx.query.hooks.findFirst({

--- a/src/server/utils/config.ts
+++ b/src/server/utils/config.ts
@@ -38,6 +38,8 @@ export const WG_ENV = {
   /** If IPv6 should be disabled */
   DISABLE_IPV6: process.env.DISABLE_IPV6 === 'true',
   WG_EXECUTABLE: await detectAwg(),
+  /** WireGuard interface name. Allows running multiple wg-easy instances on the same host. */
+  WG_INTERFACE: process.env.WG_INTERFACE ?? 'wg0',
 };
 
 export const WG_INITIAL_ENV = {

--- a/src/server/utils/ip.ts
+++ b/src/server/utils/ip.ts
@@ -93,7 +93,7 @@ function getPrivateInformation() {
   const obj: Record<string, { ipv4: string[]; ipv6: string[] }> = {};
 
   for (const name of interfaceNames) {
-    if (name === 'wg0') {
+    if (name === WG_ENV.WG_INTERFACE) {
       continue;
     }
 


### PR DESCRIPTION
## Description
Allows running multiple wg-easy instances on the same host (e.g. in
Kubernetes with hostNetwork: true) by making the WireGuard interface
name configurable via the WG_INTERFACE environment variable.

Defaults to 'wg0' — fully backwards compatible.

## Motivation and Context
When running multiple wg-easy instances on the same host using
`hostNetwork: true` (common in Kubernetes), all instances compete for
the same `wg0` interface name. The second instance to start overwrites
the first's interface configuration, causing both to fail.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
