### PR TITLE
fix(ui): prevent dark-mode FOUC and honor explicit theme toggle

### DIFF
--- a/src/app/app.vue
+++ b/src/app/app.vue
@@ -23,6 +23,18 @@ useHead({
   bodyAttrs: {
     class: 'bg-gray-50 dark:bg-neutral-800',
   },
+  // FOUC fix. @eschricht/nuxt-color-mode deliberately returns `undefined` from
+  // useClientPreferredColorScheme() during hydration to avoid Vue hydration
+  // warnings — which means it can't set <html class> in time for first paint,
+  // and on cookie changes can transiently emit an empty class. This inline
+  // blocking script does both jobs the library skips: sets the class before
+  // paint, and re-applies it whenever something else writes a different value.
+  script: [
+    {
+      tagPriority: 'critical',
+      innerHTML: `(function(){try{function resolve(){var m=document.cookie.match(/(?:^|;\\s*)theme=([^;]+)/);var p=m?decodeURIComponent(m[1]):'system';if(p==='dark')return 'dark';if(p==='light')return 'light';return matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}var h=document.documentElement;function apply(){var w=resolve();if(h.className!==w)h.className=w;}apply();new MutationObserver(apply).observe(h,{attributes:true,attributeFilter:['class']});matchMedia('(prefers-color-scheme: dark)').addEventListener('change',apply);}catch(e){}})();`,
+    },
+  ],
   link: [
     {
       rel: 'manifest',


### PR DESCRIPTION
## Description

Adds a single inline blocking `<script>` in `<head>` that sets `<html class="dark"|"light">` synchronously from the `theme` cookie + `matchMedia`, then keeps it in sync via a permanent `MutationObserver` and a `prefers-color-scheme` change listener. +12/0 lines, one file (`src/app/app.vue`).

## Motivation and Context

There are two related bugs in the current dark/light/system theme handling, both rooted in `@eschricht/nuxt-color-mode` deliberately returning `undefined` from `useClientPreferredColorScheme()` during hydration (to avoid Vue hydration warnings). That decision is fine for the library — but it means `<html class>` is unresolved until `onNuxtReady` fires, and on cookie changes the reactive `htmlAttrs.class` can transiently emit an empty value.

### Bug 1: FOUC on first load

With `theme=system` (the default) on a machine that prefers dark mode, the page briefly flashes light before settling on dark (~100ms in dev, easily visible on macOS dark mode). The hydration-time `undefined` causes the reactive `htmlAttrs.class` to resolve to the configured `fallback: 'light'`, every Tailwind `dark:` variant goes inactive, and the user sees a light flash until `onNuxtReady` fires and `matchMedia` is finally consulted.

### Bug 2: explicit toggle from `system` is ignored

Reload the page with `theme=system` on a dark-OS machine, then click the theme toggle → Light. The cookie correctly updates to `light`, but the page stays dark. The library's `useHead`-bound `htmlAttrs.class` becomes `""` (empty) instead of `"light"`, so the body retains the dark background. Symmetric bug on a light-OS machine: `system → Dark` leaves the page light.

#### Repro for Bug 2

1. Set OS preference to dark mode (or use Chrome devtools "Rendering" → "Emulate CSS prefers-color-scheme: dark").
2. Load wg-easy, ensure the `theme` cookie is `system` (the default).
3. Click the theme button to switch to Light.
4. Expected: page goes light. Actual: page stays dark; only the icon and cookie change.

### Why this approach

`@nuxtjs/color-mode` ships its own inline blocking script that would solve both bugs, but it was deliberately dropped during the Nuxt rewrite (#1333) because it caused Vue hydration mismatches. Switching back isn't desirable. Instead, this PR adds the missing inline-script layer on top of `@eschricht/nuxt-color-mode` — the library keeps doing its no-mismatch hydration, the inline script handles the parts the library skips.

## How has this been tested?

Verified across the full 6-case matrix (3 initial themes × 2 OS preferences) with Playwright, using `page.emulateMedia({ colorScheme })` to flip the OS preference. After every transition (reload + 2 toggle clicks per initial state), all three of {cookie, `<html class>`, computed body bg} match the expected resolved theme:

| OS pref | Initial theme | Cycle | Result |
|---|---|---|---|
| dark | system | system → light → dark | 3/3 ✓ |
| dark | light | light → dark → system | 3/3 ✓ |
| dark | dark | dark → system → light | 3/3 ✓ |
| light | system | system → light → dark | 3/3 ✓ |
| light | light | light → dark → system | 3/3 ✓ |
| light | dark | dark → system → light | 3/3 ✓ |

All 18 transitions pass. Bug 2 (the `system → Light` repro above) is the case in row 1, step 2 — fails before this patch, passes after.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.