### PR TITLE
Support disabling version check

### DIFF
--- a/docs/content/advanced/config/optional-config.md
+++ b/docs/content/advanced/config/optional-config.md
@@ -4,12 +4,13 @@ title: Optional Configuration
 
 You can set these environment variables to configure the container. They are not required, but can be useful in some cases.
 
-| Env            | Default   | Example     | Description                        |
-| -------------- | --------- | ----------- | ---------------------------------- |
-| `PORT`         | `51821`   | `6789`      | TCP port for Web UI.               |
-| `HOST`         | `0.0.0.0` | `localhost` | IP address web UI binds to.        |
-| `INSECURE`     | `false`   | `true`      | If access over http is allowed     |
-| `DISABLE_IPV6` | `false`   | `true`      | If IPv6 support should be disabled |
+| Env                     | Default   | Example     | Description                             |
+| ----------------------- | --------- | ----------- | --------------------------------------- |
+| `PORT`                  | `51821`   | `6789`      | TCP port for Web UI.                    |
+| `HOST`                  | `0.0.0.0` | `localhost` | IP address web UI binds to.             |
+| `INSECURE`              | `false`   | `true`      | If access over http is allowed          |
+| `DISABLE_IPV6`          | `false`   | `true`      | If IPv6 support should be disabled      |
+| `DISABLE_VERSION_CHECK` | `false`   | `true`      | If wg-easy should check for new updates |
 
 /// note | IPv6 Caveats
 

--- a/src/server/api/information.get.ts
+++ b/src/server/api/information.get.ts
@@ -1,13 +1,7 @@
 import { gt } from 'semver';
 
 export default defineEventHandler(async () => {
-  let latestRelease: Awaited<ReturnType<typeof cachedFetchLatestRelease>>;
-  if (WG_ENV.DISABLE_VERSION_CHECK) {
-    latestRelease = { version: RELEASE, changelog: '' };
-  } else {
-    latestRelease = await cachedFetchLatestRelease();
-  }
-
+  const latestRelease = await cachedFetchLatestRelease();
   const updateAvailable = gt(latestRelease.version, RELEASE);
   const insecure = WG_ENV.INSECURE;
   const isAwg = WG_ENV.WG_EXECUTABLE === 'awg';

--- a/src/server/api/information.get.ts
+++ b/src/server/api/information.get.ts
@@ -1,7 +1,13 @@
 import { gt } from 'semver';
 
 export default defineEventHandler(async () => {
-  const latestRelease = await cachedFetchLatestRelease();
+  let latestRelease: Awaited<ReturnType<typeof cachedFetchLatestRelease>>;
+  if (WG_ENV.DISABLE_VERSION_CHECK) {
+    latestRelease = { version: RELEASE, changelog: '' };
+  } else {
+    latestRelease = await cachedFetchLatestRelease();
+  }
+
   const updateAvailable = gt(latestRelease.version, RELEASE);
   const insecure = WG_ENV.INSECURE;
   const isAwg = WG_ENV.WG_EXECUTABLE === 'awg';

--- a/src/server/utils/config.ts
+++ b/src/server/utils/config.ts
@@ -38,6 +38,7 @@ export const WG_ENV = {
   /** If IPv6 should be disabled */
   DISABLE_IPV6: process.env.DISABLE_IPV6 === 'true',
   WG_EXECUTABLE: await detectAwg(),
+  DISABLE_VERSION_CHECK: process.env.DISABLE_VERSION_CHECK === 'true'
 };
 
 export const WG_INITIAL_ENV = {

--- a/src/server/utils/config.ts
+++ b/src/server/utils/config.ts
@@ -38,7 +38,7 @@ export const WG_ENV = {
   /** If IPv6 should be disabled */
   DISABLE_IPV6: process.env.DISABLE_IPV6 === 'true',
   WG_EXECUTABLE: await detectAwg(),
-  DISABLE_VERSION_CHECK: process.env.DISABLE_VERSION_CHECK === 'true'
+  DISABLE_VERSION_CHECK: process.env.DISABLE_VERSION_CHECK === 'true',
 };
 
 export const WG_INITIAL_ENV = {

--- a/src/server/utils/release.ts
+++ b/src/server/utils/release.ts
@@ -4,6 +4,13 @@ type GithubRelease = {
 };
 
 async function fetchLatestRelease() {
+  if (WG_ENV.DISABLE_VERSION_CHECK) {
+    return {
+      version: RELEASE,
+      changelog: ''
+    };
+  }
+
   try {
     const response = await $fetch<GithubRelease>(
       'https://api.github.com/repos/wg-easy/wg-easy/releases/latest',

--- a/src/server/utils/release.ts
+++ b/src/server/utils/release.ts
@@ -7,7 +7,7 @@ async function fetchLatestRelease() {
   if (WG_ENV.DISABLE_VERSION_CHECK) {
     return {
       version: RELEASE,
-      changelog: ''
+      changelog: '',
     };
   }
 


### PR DESCRIPTION
## Description
Support disabling latest version check. Closes https://github.com/wg-easy/wg-easy/issues/2500.

Please do tell if there is anything else I should do to get this merged. Thank you very much.

## Motivation and Context
Helps with air-gapped usage. Or sometimes people just don't want their WireGuard server connected to Internet.

## How has this been tested?
Default setup @ https://github.com/wg-easy/wg-easy/blob/84ed7b299f13d7e30331baf48efb5bc826167d58/docker-compose.dev.yml.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
