### PR TITLE
fix: button Delete & View Configuration on Edit Client too small

### DIFF
--- a/src/app/components/Base/FormSecondaryButton.vue
+++ b/src/app/components/Base/FormSecondaryButton.vue
@@ -2,7 +2,7 @@
   <component
     :is="elementType"
     role="button"
-    class="rounded-lg border-2 border-gray-100 text-gray-500 hover:border-red-800 hover:bg-red-800 hover:text-white focus:border-red-800 focus:outline-0 focus:ring-0 disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-100 disabled:text-gray-400 dark:border-neutral-800 dark:bg-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-400 dark:disabled:border-neutral-800 dark:disabled:bg-neutral-700 dark:disabled:text-neutral-400"
+    class="rounded-lg border-2 border-gray-100 px-4 py-2 text-gray-500 hover:border-red-800 hover:bg-red-800 hover:text-white focus:border-red-800 focus:outline-0 focus:ring-0 disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-100 disabled:text-gray-400 dark:border-neutral-800 dark:bg-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-400 dark:disabled:border-neutral-800 dark:disabled:bg-neutral-700 dark:disabled:text-neutral-400"
     v-bind="attrs"
   >
     <slot />

--- a/src/app/components/Form/PrimaryActionField.vue
+++ b/src/app/components/Form/PrimaryActionField.vue
@@ -2,7 +2,7 @@
   <input
     :value="label"
     :type="type ?? 'button'"
-    class="col-span-2 rounded-lg border-2 border-red-800 bg-red-800 py-2 text-white hover:border-red-600 hover:bg-red-600 focus:border-red-800 focus:outline-0 focus:ring-0"
+    class="col-span-2 rounded-lg border-2 border-red-800 bg-red-800 px-4 py-2 text-white hover:border-red-600 hover:bg-red-600 focus:border-red-800 focus:outline-0 focus:ring-0"
   />
 </template>
 


### PR DESCRIPTION
## Description

Add missing horizontal padding (`px-4`) to `BaseFormSecondaryButton` and `FormPrimaryActionField` components so action buttons have balanced, consistent sizing.

## Motivation and Context

The **Delete** and **View Configuration** buttons on the client detail page appeared too small — the text was cramped against the button border with no horizontal padding. 

Root cause: `BaseFormSecondaryButton` had no padding classes at all, and `FormPrimaryActionField` only had `py-2` (vertical padding) without `px-*` (horizontal padding). Other button components in the codebase (`BaseSecondaryButton`, `BasePrimaryButton`) consistently use `px-4 py-2`.

This made the form action buttons look inconsistent and harder to click compared to buttons elsewhere in the UI.

## How has this been tested?

- Verified the class changes are syntactically correct Tailwind classes
- Confirmed `px-4 py-2` matches the padding convention used by `BaseSecondaryButton` and `BasePrimaryButton` in the same component library

## Screenshots (if appropriate):

<!-- Before: buttons with text crammed against the border -->
<!-- After: buttons with consistent 16px horizontal padding -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the do
<img width="866" height="983" alt="Screenshot 2026-06-13 at 12 07 18 PM" src="https://github.com/user-attachments/assets/e143c73e-4198-426b-870d-3370fb3d2dfc" />
cumentation accordingly.

