### PR TITLE
fix: sync host routes when Server Allowed IPs change

### DIFF
--- a/src/server/utils/WireGuard.ts
+++ b/src/server/utils/WireGuard.ts
@@ -6,6 +6,7 @@ import Database from '#server/utils/Database';
 import { OLD_ENV, WG_ENV } from '#server/utils/config';
 import { firewall } from '#server/utils/firewall';
 import { encodeQRCode } from '#server/utils/qr';
+import { routes } from '#server/utils/routes';
 import type { ID } from '#server/utils/types';
 import { wg } from '#server/utils/wgHelper';
 import { setIntervalImmediately } from '#shared/utils/time';
@@ -25,6 +26,7 @@ class WireGuard {
     const wgInterface = await Database.interfaces.get();
     await this.#saveWireguardConfig(wgInterface);
     await this.#syncWireguardConfig(wgInterface);
+    await this.#applyRoutes(wgInterface);
     await this.#applyFirewallRules(wgInterface);
   }
 
@@ -40,6 +42,17 @@ class WireGuard {
       userConfig,
       !WG_ENV.DISABLE_IPV6
     );
+  }
+
+  /**
+   * Reconcile host routes so Server Allowed IPs take effect without a restart.
+   * `wg syncconf` updates peers but never touches the host routing table.
+   */
+  async #applyRoutes(wgInterface: InterfaceType) {
+    const clients = await Database.clients.getAll();
+    await routes.reconcile(wgInterface, clients, {
+      enableIpv6: !WG_ENV.DISABLE_IPV6,
+    });
   }
 
   /**

--- a/src/server/utils/routes.ts
+++ b/src/server/utils/routes.ts
@@ -149,6 +149,69 @@ function diffRoutes(
   return { toAdd, toDel };
 }
 
+export const routes = {
+  /**
+   * Reconcile the host routing table for the interface so it matches the Server
+   * Allowed IPs of all enabled clients. Runs after `wg syncconf`, which updates
+   * peers but not routes. Adds missing routes and removes stale managed ones,
+   * without bouncing the interface.
+   */
+  async reconcile(
+    wgInterface: InterfaceType,
+    clients: RoutesClient[],
+    options: { enableIpv6: boolean }
+  ): Promise<void> {
+    if (reconcileInProgress) {
+      ROUTES_DEBUG('Reconcile already in progress, queuing');
+      reconcileQueued = true;
+      return;
+    }
+
+    reconcileInProgress = true;
+
+    try {
+      const desired = collectDesiredRoutes(clients, options);
+      const families: IpVersion[] = options.enableIpv6 ? [4, 6] : [4];
+
+      for (const version of families) {
+        const output = await exec(
+          `ip -${version} route show dev ${wgInterface.name}`,
+          { log: false }
+        );
+        const current = parseDeviceRoutes(output);
+        const { toAdd, toDel } = diffRoutes(desired[version], current);
+
+        // Delete before add to avoid a transient conflict on a prefix change.
+        for (const cidr of toDel) {
+          try {
+            await exec(
+              `ip -${version} route del ${cidr} dev ${wgInterface.name}`
+            );
+          } catch (err) {
+            ROUTES_DEBUG(`Failed to remove route ${cidr}:`, err);
+          }
+        }
+        for (const cidr of toAdd) {
+          try {
+            await exec(
+              `ip -${version} route add ${cidr} dev ${wgInterface.name}`
+            );
+          } catch (err) {
+            ROUTES_DEBUG(`Failed to add route ${cidr}:`, err);
+          }
+        }
+      }
+    } finally {
+      reconcileInProgress = false;
+      if (reconcileQueued) {
+        reconcileQueued = false;
+        ROUTES_DEBUG('Processing queued reconcile');
+        await this.reconcile(wgInterface, clients, options);
+      }
+    }
+  },
+};
+
 export const routesTestExports = {
   normalizeRoute,
   isManageable,

--- a/src/server/utils/routes.ts
+++ b/src/server/utils/routes.ts
@@ -1,0 +1,73 @@
+import { parseCidr, containsCidr } from 'cidr-tools';
+import { stringifyIp } from 'ip-bigint';
+import { createDebug } from 'obug';
+
+import { exec } from '#server/utils/cmd';
+import type { ClientType } from '#db/repositories/client/types';
+import type { InterfaceType } from '#db/repositories/interface/types';
+
+const ROUTES_DEBUG = createDebug('Routes');
+
+// Mutex to prevent concurrent route reconciles
+let reconcileInProgress = false;
+let reconcileQueued = false;
+
+type IpVersion = 4 | 6;
+
+type NormalizedRoute = {
+  cidr: string;
+  version: IpVersion;
+};
+
+type DeviceRoute = {
+  cidr: string;
+  managed: boolean;
+};
+
+type DesiredRoutes = {
+  4: Set<string>;
+  6: Set<string>;
+};
+
+type RoutesClient = Pick<ClientType, 'enabled' | 'serverAllowedIps'>;
+
+/**
+ * Canonicalize a Server Allowed IPs entry to `network/prefix` form.
+ * `192.168.120.5/22` -> `192.168.120.0/22`; a bare IP gains `/32` or `/128`.
+ * Returns null for input cidr-tools cannot parse (serverAllowedIps is validated
+ * only as a permissive string).
+ */
+function normalizeRoute(entry: string): NormalizedRoute | null {
+  try {
+    const parsed = parseCidr(entry);
+    const network = stringifyIp({
+      number: parsed.start,
+      version: parsed.version,
+    });
+    return { cidr: `${network}/${parsed.prefix}`, version: parsed.version };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether wg-easy should add/remove this route. Excludes default routes (they
+ * need wg-quick's policy routing) and IPv6 link-local / multicast.
+ */
+function isManageable(cidr: string, version: IpVersion): boolean {
+  if (cidr.endsWith('/0')) {
+    return false;
+  }
+  if (
+    version === 6 &&
+    (containsCidr('fe80::/10', cidr) || containsCidr('ff00::/8', cidr))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export const routesTestExports = {
+  normalizeRoute,
+  isManageable,
+};

--- a/src/server/utils/routes.ts
+++ b/src/server/utils/routes.ts
@@ -99,8 +99,40 @@ function collectDesiredRoutes(
   return desired;
 }
 
+/**
+ * Parse `ip route show dev <inf>` output into routes tagged with whether wg-easy
+ * manages them. Kernel-installed routes (the connected subnet, link-local,
+ * multicast) are present but flagged unmanaged, so they are never removed and
+ * never re-added.
+ */
+function parseDeviceRoutes(output: string): DeviceRoute[] {
+  const result: DeviceRoute[] = [];
+
+  for (const line of output.trim().split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const dest = trimmed.split(/\s+/)[0];
+    if (!dest || dest === 'default') {
+      continue;
+    }
+    const normalized = normalizeRoute(dest);
+    if (!normalized) {
+      continue;
+    }
+    const managed =
+      !trimmed.includes('proto kernel') &&
+      isManageable(normalized.cidr, normalized.version);
+    result.push({ cidr: normalized.cidr, managed });
+  }
+
+  return result;
+}
+
 export const routesTestExports = {
   normalizeRoute,
   isManageable,
   collectDesiredRoutes,
+  parseDeviceRoutes,
 };

--- a/src/server/utils/routes.ts
+++ b/src/server/utils/routes.ts
@@ -67,7 +67,40 @@ function isManageable(cidr: string, version: IpVersion): boolean {
   return true;
 }
 
+/**
+ * Build the desired managed routes (per IP family) from enabled clients'
+ * Server Allowed IPs. IPv6 is dropped when IPv6 is disabled.
+ */
+function collectDesiredRoutes(
+  clients: RoutesClient[],
+  options: { enableIpv6: boolean }
+): DesiredRoutes {
+  const desired: DesiredRoutes = { 4: new Set(), 6: new Set() };
+
+  for (const client of clients) {
+    if (!client.enabled) {
+      continue;
+    }
+    for (const entry of client.serverAllowedIps ?? []) {
+      const normalized = normalizeRoute(entry);
+      if (!normalized) {
+        continue;
+      }
+      if (!isManageable(normalized.cidr, normalized.version)) {
+        continue;
+      }
+      if (normalized.version === 6 && !options.enableIpv6) {
+        continue;
+      }
+      desired[normalized.version].add(normalized.cidr);
+    }
+  }
+
+  return desired;
+}
+
 export const routesTestExports = {
   normalizeRoute,
   isManageable,
+  collectDesiredRoutes,
 };

--- a/src/server/utils/routes.ts
+++ b/src/server/utils/routes.ts
@@ -130,9 +130,29 @@ function parseDeviceRoutes(output: string): DeviceRoute[] {
   return result;
 }
 
+/**
+ * Compute which routes to add and which managed routes to remove. A desired
+ * route already present in any form (including a kernel route) is not re-added;
+ * only managed routes are removed.
+ */
+function diffRoutes(
+  desired: Set<string>,
+  current: DeviceRoute[]
+): { toAdd: string[]; toDel: string[] } {
+  const currentCidrs = new Set(current.map((route) => route.cidr));
+
+  const toAdd = [...desired].filter((cidr) => !currentCidrs.has(cidr));
+  const toDel = current
+    .filter((route) => route.managed && !desired.has(route.cidr))
+    .map((route) => route.cidr);
+
+  return { toAdd, toDel };
+}
+
 export const routesTestExports = {
   normalizeRoute,
   isManageable,
   collectDesiredRoutes,
   parseDeviceRoutes,
+  diffRoutes,
 };

--- a/src/test/unit/routes.spec.ts
+++ b/src/test/unit/routes.spec.ts
@@ -7,6 +7,7 @@ const {
   isManageable,
   collectDesiredRoutes,
   parseDeviceRoutes,
+  diffRoutes,
 } = routesTestExports;
 
 describe('routes', () => {
@@ -142,6 +143,40 @@ describe('routes', () => {
         { cidr: 'fe80::/64', managed: false },
         { cidr: '2001:db8::/64', managed: true },
       ]);
+    });
+  });
+
+  describe('diffRoutes', () => {
+    test('adds desired routes that are not present', () => {
+      const current = [{ cidr: '100.255.1.0/24', managed: false }];
+      const { toAdd, toDel } = diffRoutes(
+        new Set(['192.168.120.0/22']),
+        current
+      );
+      expect(toAdd).toEqual(['192.168.120.0/22']);
+      expect(toDel).toEqual([]);
+    });
+    test('removes stale managed routes', () => {
+      const current = [
+        { cidr: '192.168.120.0/22', managed: true },
+        { cidr: '10.10.0.0/24', managed: true },
+      ];
+      const { toAdd, toDel } = diffRoutes(
+        new Set(['192.168.120.0/22']),
+        current
+      );
+      expect(toAdd).toEqual([]);
+      expect(toDel).toEqual(['10.10.0.0/24']);
+    });
+    test('never removes unmanaged routes', () => {
+      const current = [{ cidr: '100.255.1.0/24', managed: false }];
+      const { toDel } = diffRoutes(new Set(), current);
+      expect(toDel).toEqual([]);
+    });
+    test('does not re-add a route already present as a kernel route', () => {
+      const current = [{ cidr: '100.255.1.0/24', managed: false }];
+      const { toAdd } = diffRoutes(new Set(['100.255.1.0/24']), current);
+      expect(toAdd).toEqual([]);
     });
   });
 });

--- a/src/test/unit/routes.spec.ts
+++ b/src/test/unit/routes.spec.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from 'vitest';
 
 import { routesTestExports } from '#server/utils/routes';
 
-const { normalizeRoute, isManageable } = routesTestExports;
+const { normalizeRoute, isManageable, collectDesiredRoutes } =
+  routesTestExports;
 
 describe('routes', () => {
   describe('normalizeRoute', () => {
@@ -48,6 +49,65 @@ describe('routes', () => {
     test('accepts ordinary subnets', () => {
       expect(isManageable('192.168.120.0/22', 4)).toBe(true);
       expect(isManageable('2001:db8::/64', 6)).toBe(true);
+    });
+  });
+
+  describe('collectDesiredRoutes', () => {
+    test('unions enabled clients and splits by family', () => {
+      const result = collectDesiredRoutes(
+        [
+          {
+            enabled: true,
+            serverAllowedIps: ['192.168.120.0/22', '2001:db8::/64'],
+          },
+          { enabled: true, serverAllowedIps: ['10.10.0.0/24'] },
+        ],
+        { enableIpv6: true }
+      );
+      expect([...result[4]].sort()).toEqual([
+        '10.10.0.0/24',
+        '192.168.120.0/22',
+      ]);
+      expect([...result[6]]).toEqual(['2001:db8::/64']);
+    });
+    test('ignores disabled clients', () => {
+      const result = collectDesiredRoutes(
+        [{ enabled: false, serverAllowedIps: ['192.168.120.0/22'] }],
+        { enableIpv6: true }
+      );
+      expect(result[4].size).toBe(0);
+    });
+    test('dedupes and normalizes host bits across clients', () => {
+      const result = collectDesiredRoutes(
+        [
+          { enabled: true, serverAllowedIps: ['192.168.120.5/22'] },
+          { enabled: true, serverAllowedIps: ['192.168.120.99/22'] },
+        ],
+        { enableIpv6: true }
+      );
+      expect([...result[4]]).toEqual(['192.168.120.0/22']);
+    });
+    test('drops default routes', () => {
+      const result = collectDesiredRoutes(
+        [{ enabled: true, serverAllowedIps: ['0.0.0.0/0', '::/0'] }],
+        { enableIpv6: true }
+      );
+      expect(result[4].size).toBe(0);
+      expect(result[6].size).toBe(0);
+    });
+    test('drops IPv6 when disabled', () => {
+      const result = collectDesiredRoutes(
+        [{ enabled: true, serverAllowedIps: ['2001:db8::/64'] }],
+        { enableIpv6: false }
+      );
+      expect(result[6].size).toBe(0);
+    });
+    test('skips unparseable entries', () => {
+      const result = collectDesiredRoutes(
+        [{ enabled: true, serverAllowedIps: ['garbage', '10.0.0.0/24'] }],
+        { enableIpv6: true }
+      );
+      expect([...result[4]]).toEqual(['10.0.0.0/24']);
     });
   });
 });

--- a/src/test/unit/routes.spec.ts
+++ b/src/test/unit/routes.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest';
+
+import { routesTestExports } from '#server/utils/routes';
+
+const { normalizeRoute, isManageable } = routesTestExports;
+
+describe('routes', () => {
+  describe('normalizeRoute', () => {
+    test('canonicalizes IPv4 host bits to the network address', () => {
+      expect(normalizeRoute('192.168.120.5/22')).toEqual({
+        cidr: '192.168.120.0/22',
+        version: 4,
+      });
+    });
+    test('adds /32 to a bare IPv4 address', () => {
+      expect(normalizeRoute('10.0.0.5')).toEqual({
+        cidr: '10.0.0.5/32',
+        version: 4,
+      });
+    });
+    test('canonicalizes IPv6 host bits to the network address', () => {
+      expect(normalizeRoute('2001:db8::5/64')).toEqual({
+        cidr: '2001:db8::/64',
+        version: 6,
+      });
+    });
+    test('adds /128 to a bare IPv6 address', () => {
+      expect(normalizeRoute('2001:db8::1')).toEqual({
+        cidr: '2001:db8::1/128',
+        version: 6,
+      });
+    });
+    test('returns null for unparseable input', () => {
+      expect(normalizeRoute('garbage')).toBeNull();
+      expect(normalizeRoute('')).toBeNull();
+    });
+  });
+
+  describe('isManageable', () => {
+    test('rejects default routes', () => {
+      expect(isManageable('0.0.0.0/0', 4)).toBe(false);
+      expect(isManageable('::/0', 6)).toBe(false);
+    });
+    test('rejects IPv6 link-local and multicast', () => {
+      expect(isManageable('fe80::/64', 6)).toBe(false);
+      expect(isManageable('ff00::/8', 6)).toBe(false);
+    });
+    test('accepts ordinary subnets', () => {
+      expect(isManageable('192.168.120.0/22', 4)).toBe(true);
+      expect(isManageable('2001:db8::/64', 6)).toBe(true);
+    });
+  });
+});

--- a/src/test/unit/routes.spec.ts
+++ b/src/test/unit/routes.spec.ts
@@ -2,8 +2,12 @@ import { describe, expect, test } from 'vitest';
 
 import { routesTestExports } from '#server/utils/routes';
 
-const { normalizeRoute, isManageable, collectDesiredRoutes } =
-  routesTestExports;
+const {
+  normalizeRoute,
+  isManageable,
+  collectDesiredRoutes,
+  parseDeviceRoutes,
+} = routesTestExports;
 
 describe('routes', () => {
   describe('normalizeRoute', () => {
@@ -108,6 +112,36 @@ describe('routes', () => {
         { enableIpv6: true }
       );
       expect([...result[4]]).toEqual(['10.0.0.0/24']);
+    });
+  });
+
+  describe('parseDeviceRoutes', () => {
+    test('flags the kernel connected route as unmanaged', () => {
+      const output = [
+        '100.255.1.0/24 proto kernel scope link src 100.255.1.1',
+        '192.168.120.0/22 scope link',
+      ].join('\n');
+      expect(parseDeviceRoutes(output)).toEqual([
+        { cidr: '100.255.1.0/24', managed: false },
+        { cidr: '192.168.120.0/22', managed: true },
+      ]);
+    });
+    test('skips default routes', () => {
+      expect(parseDeviceRoutes('default via 10.0.0.1')).toEqual([]);
+    });
+    test('handles empty output', () => {
+      expect(parseDeviceRoutes('')).toEqual([]);
+      expect(parseDeviceRoutes('\n  \n')).toEqual([]);
+    });
+    test('flags IPv6 link-local kernel route as unmanaged', () => {
+      const output = [
+        'fe80::/64 proto kernel metric 256 pref medium',
+        '2001:db8::/64 metric 1024 pref medium',
+      ].join('\n');
+      expect(parseDeviceRoutes(output)).toEqual([
+        { cidr: 'fe80::/64', managed: false },
+        { cidr: '2001:db8::/64', managed: true },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Description

Adds a route reconciliation step so that changing a client's "Server Allowed IPs"
takes effect immediately, without restarting the interface.

`saveConfig()` applies live changes with `wg syncconf`, which updates the WireGuard
peers/AllowedIPs in the kernel but never touches the host routing table. Host routes
were only created by `wg-quick up` at startup/restart, so a newly added Server
Allowed IPs subnet showed up in `wg show` but had no entry in `ip route`, and the
server never forwarded traffic for it into the tunnel.

New `server/utils/routes.ts`, mirroring the existing `firewall.ts` rebuild pattern:
- derives the desired routes from every enabled client's `serverAllowedIps`,
- compares them against `ip route show dev <inf>`,
- adds missing routes and removes stale ones, without bouncing the interface.

Only non-kernel routes on the wg interface are managed (the same set `wg-quick`
removes on restart). Default routes (`0.0.0.0/0`, `::/0`) and IPv6 link-local /
multicast are left untouched. It is wired into `WireGuard.saveConfig()` as
`#applyRoutes`, between the sync and the firewall rebuild. Adding and removing a
Server Allowed IP now both apply live.

## Motivation and Context

Fixes #2171 (status: confirmed). The documented workaround was to restart the
interface; this makes the change apply on save.

## How has this been tested?

- New `test/unit/routes.spec.ts` (22 cases): CIDR normalization, desired-route
  collection (enabled-only, dedup, default/IPv6 filtering), `ip route` output
  parsing (kernel/link-local flagged unmanaged), and the add/remove diff. The pure
  helpers are unit tested; the `exec`-driven `reconcile()` is left out of unit
  tests, the same boundary `firewall.ts` draws.
- `pnpm test:unit` (51 passed), `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
  all pass.
- Still to validate on a live instance: add a subnet to a client's Server Allowed
  IPs and confirm `ip route show dev wg0` lists it without a restart; remove it and
  confirm the route disappears.

## Screenshots (if appropriate):

N/A (server-side routing change).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
