### PR TITLE
fix: trace cli dependencies

### DIFF
--- a/src/cli/build.js
+++ b/src/cli/build.js
@@ -1,10 +1,47 @@
 // @ts-check
 
+import { writeFile, mkdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
 import esbuild from 'esbuild';
 
-esbuild.build({
+const isTrace =
+  process.argv.slice(2).findIndex((arg) => arg === '--trace') !== -1;
+
+/**
+ * Writes files with needed imports to `../node_modules/.cache/wg-easy/trace.mjs`
+ *
+ * @param {import('esbuild').Metafile} metafile
+ */
+async function writeTrace(metafile) {
+  const paths = [
+    ...new Set(
+      Object.values(metafile.outputs).flatMap((v) =>
+        v.imports.map((v) => v.path)
+      )
+    ),
+  ];
+  const imports = paths.map((v) => `import '${v}';`).join('\n');
+
+  const folderUrl = new URL('../node_modules/.cache/wg-easy/', import.meta.url);
+  const folder = fileURLToPath(folderUrl);
+  const filePath = fileURLToPath(new URL('./trace.mjs', folderUrl));
+
+  await mkdir(folder, { recursive: true });
+  await writeFile(filePath, imports);
+}
+
+function getOverrides() {
+  if (isTrace) {
+    return {
+      outfile: undefined,
+      write: false,
+    };
+  }
+  return {};
+}
+
+const result = await esbuild.build({
   entryPoints: [fileURLToPath(new URL('./index.ts', import.meta.url))],
   bundle: true,
   outfile: fileURLToPath(new URL('../.output/server/cli.mjs', import.meta.url)),
@@ -12,4 +49,10 @@ esbuild.build({
   format: 'esm',
   packages: 'external',
   logLevel: 'info',
+  metafile: true,
+  ...getOverrides(),
 });
+
+if (isTrace) {
+  await writeTrace(result.metafile);
+}

--- a/src/nuxt.config.ts
+++ b/src/nuxt.config.ts
@@ -166,7 +166,11 @@ export default defineNuxtConfig({
       },
     },
     externals: {
-      traceInclude: [fileURLToPath(new URL('./cli/index.ts', import.meta.url))],
+      traceInclude: [
+        fileURLToPath(
+          new URL('./node_modules/.cache/wg-easy/trace.mjs', import.meta.url)
+        ),
+      ],
     },
   },
   alias: {

--- a/src/package.json
+++ b/src/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "nuxt build && pnpm cli:build",
+    "build": "pnpm cli:trace && nuxt build && pnpm cli:build",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
@@ -16,6 +16,7 @@
     "typecheck": "nuxt typecheck",
     "check:all": "pnpm typecheck && pnpm lint && pnpm format:check && pnpm build",
     "db:generate": "drizzle-kit generate",
+    "cli:trace": "node cli/build.js --trace",
     "cli:build": "node cli/build.js",
     "cli:dev": "tsx cli/index.ts",
     "test:unit": "vitest run --project unit"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
nitro v2 uses @vercel/nft to trace dependencies.
@vercel/nft does not support typescript and fails to trace dependencies for the cli
this uses esbuild to generate a file with all needed imports from the metafile

## Motivation and Context
Closes #2682 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
