### PR TITLE
feat(auth): optional trusted-header SSO (reverse-proxy authentication)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# wg-easy environment variables
+# Copy to `.env` and adjust. All values below are optional unless noted.
+# Full reference: docs/content/advanced/config/optional-config.md
+
+# --- Web UI ---
+# PORT=51821
+# HOST=0.0.0.0
+# INSECURE=false
+# DISABLE_IPV6=false
+# DISABLE_VERSION_CHECK=false
+
+# --- Trusted-header SSO (Culpur fork) ---
+# Trust an upstream reverse proxy (e.g. an Authentik forward-auth outpost) that
+# has already authenticated the user and asserts their identity via headers.
+# Disabled unless TRUSTED_PROXY_ENABLED=true. Reuses the OAuth account machinery
+# (oauth_provider=trusted-header) and the OAUTH_AUTO_REGISTER gate.
+#
+# SECURITY: the shared secret is the trust boundary — Docker SNAT makes the peer
+# IP non-discriminating, so the secret (not the source IP) proves a request came
+# from the proxy. The feature fails closed if enabled without a secret. Your
+# proxy MUST strip client-supplied identity headers and set its own.
+# TRUSTED_PROXY_ENABLED=true
+# TRUSTED_PROXY_SECRET=change-me-to-a-long-random-value
+# TRUSTED_PROXY_SECRET_HEADER=x-wg-proxy-secret
+# TRUSTED_PROXY_HEADER=x-authentik-username
+# TRUSTED_PROXY_EMAIL_HEADER=x-authentik-email
+# TRUSTED_PROXY_NAME_HEADER=x-authentik-name
+# TRUSTED_PROXY_IPS=
+# TRUSTED_PROXY_DEFAULT_ROLE=client
+# Auto-provision users the proxy authenticates (shared with OAuth):
+# OAUTH_AUTO_REGISTER=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,18 @@ services:
     #  - PORT=51821
     #  - HOST=0.0.0.0
     #  - INSECURE=false
+    #  Trusted-header SSO (trust an upstream forward-auth proxy, e.g. Authentik).
+    #  Disabled unless TRUSTED_PROXY_ENABLED=true. The shared secret is the trust
+    #  boundary — see docs/advanced/config/optional-config.
+    #  - TRUSTED_PROXY_ENABLED=true
+    #  - TRUSTED_PROXY_SECRET=change-me-to-a-long-random-value
+    #  - OAUTH_AUTO_REGISTER=true          # auto-provision proxy-authenticated users
+    #  - TRUSTED_PROXY_HEADER=x-authentik-username
+    #  - TRUSTED_PROXY_EMAIL_HEADER=x-authentik-email
+    #  - TRUSTED_PROXY_NAME_HEADER=x-authentik-name
+    #  - TRUSTED_PROXY_SECRET_HEADER=x-wg-proxy-secret
+    #  - TRUSTED_PROXY_IPS=               # optional source-IP allowlist (see docs)
+    #  - TRUSTED_PROXY_DEFAULT_ROLE=client
 
     image: ghcr.io/wg-easy/wg-easy:15
     container_name: wg-easy

--- a/docs/content/advanced/config/optional-config.md
+++ b/docs/content/advanced/config/optional-config.md
@@ -21,3 +21,30 @@ You will however still see a IPv6 address in the Web UI, but it won't be used.
 This option can be removed in the future, as more devices support IPv6.
 
 ///
+
+## Trusted-Header SSO
+
+Trust an upstream reverse proxy that has _already_ authenticated the user (e.g. an [Authentik](https://goauthentik.io/) forward-auth outpost) and asserts the user's identity through request headers. When enabled and the request proves it came from the trusted proxy, wg-easy establishes a session for the matching user, reusing the OAuth account machinery (`oauth_provider` = `trusted-header`) and the [`OAUTH_AUTO_REGISTER`](./external-authentication.md#auto-register) gate to auto-provision when the user does not yet exist.
+
+This is **disabled by default**; stock behaviour is unchanged unless `TRUSTED_PROXY_ENABLED` is set.
+
+| Env                           | Default                | Example             | Description                                                                              |
+| ----------------------------- | ---------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `TRUSTED_PROXY_ENABLED`       | `false`                | `true`              | Enable trusted-header SSO.                                                               |
+| `TRUSTED_PROXY_SECRET`        | -                      | `<random-64-hex>`   | Shared secret the proxy must inject. **Required** when enabled (fails closed if absent). |
+| `TRUSTED_PROXY_SECRET_HEADER` | `x-wg-proxy-secret`    | `x-wg-proxy-secret` | Header carrying the shared secret.                                                       |
+| `TRUSTED_PROXY_HEADER`        | `x-authentik-username` | `x-forwarded-user`  | Header carrying the verified username.                                                   |
+| `TRUSTED_PROXY_EMAIL_HEADER`  | `x-authentik-email`    | `x-forwarded-email` | Optional header carrying the verified email (used for account linking).                  |
+| `TRUSTED_PROXY_NAME_HEADER`   | `x-authentik-name`     | `x-forwarded-name`  | Optional header carrying the display name.                                               |
+| `TRUSTED_PROXY_IPS`           | -                      | `10.42.42.1`        | Optional comma-separated allowlist of proxy source IPs (defense-in-depth).               |
+| `TRUSTED_PROXY_DEFAULT_ROLE`  | `client`               | `admin`             | Role for auto-provisioned users: `client` or `admin`.                                    |
+
+/// warning | Security — the secret is the trust boundary
+
+Any client can forge HTTP headers, so wg-easy must be able to tell a request from the trusted proxy apart from any other host that can reach the published port. The **shared secret** (`TRUSTED_PROXY_SECRET`) is that proof: the proxy injects it, wg-easy verifies it with a constant-time compare, and the feature fails closed if it is unset while enabled.
+
+The source-IP allowlist (`TRUSTED_PROXY_IPS`) is only optional defense-in-depth. In a typical Docker deployment it is **not** discriminating: Docker SNATs every inbound connection to the bridge gateway, so the observed peer IP is the same for the proxy and for any other container/host reaching the port. Rely on the secret; add the IP allowlist only when your network topology makes the real peer IP meaningful.
+
+Your proxy **must** strip any client-supplied identity headers (`TRUSTED_PROXY_HEADER`, `_EMAIL_HEADER`, `_NAME_HEADER`) and set its own, so a browser can never pre-set them.
+
+///

--- a/src/app/pages/me.vue
+++ b/src/app/pages/me.vue
@@ -184,12 +184,25 @@ const { data: authMethods } = await useFetch('/api/auth/methods');
 const name = ref(authStore.userData?.name);
 const email = ref(authStore.userData?.email);
 const hasPassword = computed(() => authStore.userData?.hasPassword);
-const oauthProvider = computed(() => authStore.userData?.oauthProvider);
+// Real, click-to-login OAuth providers. The 'trusted-header' pseudo-provider
+// (Culpur fork) is intentionally excluded: it has no link/unlink UI, so a
+// trusted-header user is treated here as having no linkable OAuth provider.
+const OAUTH_LOGIN_PROVIDERS: OAUTH_PROVIDER[] = ['google', 'github', 'oidc'];
+function isOauthLoginProvider(
+  provider: string | null | undefined
+): provider is OAUTH_PROVIDER {
+  return !!provider && (OAUTH_LOGIN_PROVIDERS as string[]).includes(provider);
+}
+const oauthProvider = computed(() => {
+  const provider = authStore.userData?.oauthProvider;
+  return isOauthLoginProvider(provider) ? provider : undefined;
+});
 const oauthProviderInfo = computed(() => {
-  if (!authStore.userData?.oauthProvider) {
+  const provider = oauthProvider.value;
+  if (!provider) {
     return null;
   }
-  return authMethods.value?.providers?.[authStore.userData.oauthProvider];
+  return authMethods.value?.providers?.[provider];
 });
 
 const _submit = useSubmit(

--- a/src/server/database/repositories/user/schema.ts
+++ b/src/server/database/repositories/user/schema.ts
@@ -4,7 +4,7 @@ import { int, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
 import { client } from '../client/schema';
 
 import type { Role } from '#shared/utils/permissions';
-import type { OAUTH_PROVIDER } from '#server/utils/oauth';
+import type { AUTH_PROVIDER } from '#server/utils/oauth';
 
 export const user = sqliteTable(
   'users_table',
@@ -19,7 +19,7 @@ export const user = sqliteTable(
     totpKey: text('totp_key'),
     totpVerified: int('totp_verified', { mode: 'boolean' }).notNull(),
     enabled: int({ mode: 'boolean' }).notNull(),
-    oauthProvider: text('oauth_provider').$type<OAUTH_PROVIDER>(),
+    oauthProvider: text('oauth_provider').$type<AUTH_PROVIDER>(),
     oauthId: text('oauth_id'),
     createdAt: text('created_at')
       .notNull()

--- a/src/server/database/repositories/user/service.ts
+++ b/src/server/database/repositories/user/service.ts
@@ -6,9 +6,11 @@ import type { UserType } from './types';
 
 import { WG_ENV } from '#server/utils/config';
 import type { OAUTH_PROVIDER } from '#server/utils/oauth';
+import { TRUSTED_HEADER_PROVIDER } from '#server/utils/oauth';
 import { hashPassword, isPasswordValid } from '#server/utils/password';
 import type { ID } from '#server/utils/types';
 import { roles } from '#shared/utils/permissions';
+import type { Role } from '#shared/utils/permissions';
 import type { DBType } from '#db/sqlite';
 
 type LoginResult =
@@ -387,6 +389,121 @@ export class UserService {
           email,
           name,
           role: roles.ADMIN,
+          totpVerified: false,
+          enabled: true,
+          oauthProvider: provider,
+          oauthId,
+        })
+        .returning();
+      const newUser = newUsers[0];
+
+      if (!newUser) {
+        return { success: false as const, error: 'UNEXPECTED_ERROR' as const };
+      }
+      return { success: true as const, user: newUser };
+    });
+  }
+
+  /**
+   * Login or register a user asserted by a trusted upstream proxy
+   * (trusted-header SSO, Culpur fork).
+   *
+   * Reuses the same OAuth account machinery as {@link loginWithOAuth}
+   * (oauth_provider = 'trusted-header', oauth_id = the proxy's stable subject)
+   * and honours the same OAUTH_AUTO_REGISTER gate, so a trusted-header identity
+   * behaves like any other linked/auto-registered account downstream.
+   *
+   * Differs from {@link loginWithOAuth} in two ways that the header transport
+   * requires:
+   *  - `email` is optional. The proxy may not assert one, so lookup is keyed on
+   *    (provider, oauthId); email-based linking only runs when an email is
+   *    present. `loginWithOAuth` mandates a verified email, which we can't
+   *    guarantee here.
+   *  - the auto-provisioned role is configurable via TRUSTED_PROXY_DEFAULT_ROLE
+   *    rather than always ADMIN.
+   */
+  async loginWithTrustedHeader(
+    oauthId: string,
+    username: string,
+    email: string | null,
+    name: string,
+    defaultRole: Role
+  ): Promise<LoginWithOAuthResult> {
+    const provider = TRUSTED_HEADER_PROVIDER;
+    return this.#db.transaction(async (tx) => {
+      const userById = await tx.query.user
+        .findFirst({
+          where: and(
+            eq(user.oauthProvider, provider),
+            eq(user.oauthId, oauthId)
+          ),
+        })
+        .execute();
+
+      if (userById) {
+        if (!userById.enabled) {
+          return { success: false, error: 'USER_DISABLED' };
+        }
+        if (userById.totpVerified) {
+          return {
+            success: false,
+            error: 'TOTP_REQUIRED',
+            userId: userById.id,
+          };
+        }
+        return { success: true, user: userById };
+      }
+
+      // Link an existing local account only when the proxy asserts an email we
+      // can match against; without one there is no safe way to link.
+      if (email) {
+        const userByEmail = await tx.query.user
+          .findFirst({
+            where: eq(user.email, email),
+          })
+          .execute();
+
+        if (userByEmail) {
+          if (!userByEmail.enabled) {
+            return { success: false, error: 'USER_DISABLED' };
+          }
+          if (userByEmail.oauthProvider && userByEmail.oauthId) {
+            return {
+              success: false,
+              error: 'USER_ALREADY_LINKED',
+            };
+          }
+
+          await tx
+            .update(user)
+            .set({ oauthProvider: provider, oauthId: oauthId })
+            .where(eq(user.id, userByEmail.id))
+            .execute();
+
+          if (userByEmail.totpVerified) {
+            return {
+              success: false,
+              error: 'TOTP_REQUIRED',
+              userId: userByEmail.id,
+            };
+          }
+
+          return { success: true, user: userByEmail };
+        }
+      }
+
+      if (!WG_ENV.OAUTH_AUTO_REGISTER) {
+        return { success: false, error: 'AUTO_REGISTER_DISABLED' };
+      }
+
+      const newUsers = await tx
+        .insert(user)
+        .values({
+          username,
+          password: null,
+          email,
+          name,
+          role: defaultRole,
           totpVerified: false,
           enabled: true,
           oauthProvider: provider,

--- a/src/server/middleware/trustedAuth.ts
+++ b/src/server/middleware/trustedAuth.ts
@@ -1,0 +1,146 @@
+import { timingSafeEqual } from 'node:crypto';
+
+import { defineEventHandler, getHeader, getRequestIP, getRequestURL } from 'h3';
+
+import Database from '#server/utils/Database';
+import { SERVER_DEBUG, WG_ENV } from '#server/utils/config';
+import { getWGSession, useWGSession } from '#server/utils/session';
+import { roles } from '#shared/utils/permissions';
+
+/*
+ * Trusted-header SSO (Culpur Defense fork).
+ *
+ * Runs before route handlers. When TRUSTED_PROXY_ENABLED is set and the request
+ * proves it came from the trusted proxy, this reads the identity header that a
+ * trusted upstream (an Authentik forward-auth outpost) has asserted, resolves or
+ * auto-provisions the matching wg-easy user via the same OAuth account machinery
+ * upstream uses (Database.users.loginWithTrustedHeader, oauth_provider =
+ * 'trusted-header'), and establishes the normal wg-easy session — exactly the
+ * way the OAuth callback does (session.update({ userId })). Everything downstream
+ * (getCurrentUser -> definePermissionEventHandler -> RBAC) then works unchanged.
+ *
+ * SECURITY MODEL — why this is not an auth bypass:
+ *   1. Off by default. Stock wg-easy never runs this branch.
+ *   2. Shared secret (PRIMARY). The proxy injects TRUSTED_PROXY_SECRET_HEADER with
+ *      a secret only it knows; wg-easy verifies it with a constant-time compare. A
+ *      direct-to-port attacker on the LAN cannot forge it. THIS is the real trust
+ *      boundary in a shared-bridge topology, where Docker SNATs every inbound
+ *      connection to the bridge gateway so the source IP alone can't tell the
+ *      proxy apart from any other host that can reach the published port.
+ *   3. Source-IP allowlist (OPTIONAL defense-in-depth). If TRUSTED_PROXY_IPS is
+ *      set, the real socket peer must also match. Read via getRequestIP(event,
+ *      { xForwardedFor: false }) — the connection remoteAddress, NOT the spoofable
+ *      X-Forwarded-For. Left empty when SNAT makes the peer non-discriminating.
+ *
+ * In our topology the outpost also strips any client-supplied identity headers
+ * and sets its own, so the identity header cannot arrive pre-set from a browser.
+ *
+ * If the feature is disabled, the secret is missing/wrong, the (optional) IP check
+ * fails, or no identity header is present, this middleware does nothing and the
+ * request falls through to the existing password/session auth untouched.
+ */
+
+/** Constant-time string compare that never throws on length/'' mismatch. */
+function secretMatches(
+  provided: string | undefined,
+  expected: string
+): boolean {
+  if (!provided) {
+    return false;
+  }
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+export default defineEventHandler(async (event) => {
+  if (!WG_ENV.TRUSTED_PROXY_ENABLED) {
+    return;
+  }
+
+  // Fail closed: enabling the feature without a secret must NOT trust anything.
+  if (!WG_ENV.TRUSTED_PROXY_SECRET) {
+    return;
+  }
+
+  // Only act on API calls and page loads; leave setup/i18n alone (mirrors setup.ts).
+  const url = getRequestURL(event);
+  if (
+    url.pathname.startsWith('/_i18n/') ||
+    url.pathname.startsWith('/setup/')
+  ) {
+    return;
+  }
+
+  // 1a. Trust gate — the proxy-injected shared secret must match (constant time).
+  const providedSecret = getHeader(event, WG_ENV.TRUSTED_PROXY_SECRET_HEADER);
+  if (!secretMatches(providedSecret, WG_ENV.TRUSTED_PROXY_SECRET)) {
+    SERVER_DEBUG(
+      `Trusted-header SSO: secret check failed for ${url.pathname} ` +
+        `(header '${WG_ENV.TRUSTED_PROXY_SECRET_HEADER}' present=${!!providedSecret})`
+    );
+    return;
+  }
+
+  // 1b. Optional defense-in-depth — if an IP allowlist is configured, the real
+  //     socket peer must also be in it. Skipped when the list is empty (SNAT case).
+  if (WG_ENV.TRUSTED_PROXY_IPS.length > 0) {
+    const peer = getRequestIP(event, { xForwardedFor: false });
+    if (!peer || !WG_ENV.TRUSTED_PROXY_IPS.includes(peer)) {
+      SERVER_DEBUG(`Trusted-header SSO: peer ${peer} not in allowlist`);
+      return;
+    }
+  }
+
+  // 2. Read the identity the upstream verified.
+  const username = getHeader(event, WG_ENV.TRUSTED_PROXY_HEADER)?.trim();
+  if (!username) {
+    SERVER_DEBUG(
+      `Trusted-header SSO: secret OK but no username header ` +
+        `('${WG_ENV.TRUSTED_PROXY_HEADER}') on ${url.pathname}`
+    );
+    return;
+  }
+
+  // If a valid session already exists for this same user, don't re-mint it.
+  const existingSession = await getWGSession(event);
+  if (existingSession.data.userId) {
+    const current = await Database.users.get(existingSession.data.userId);
+    if (current && current.username === username) {
+      return;
+    }
+  }
+
+  // 3. Resolve or provision the federated user via the shared OAuth machinery,
+  //    then establish the session the same way the OAuth callback does.
+  const email = getHeader(event, WG_ENV.TRUSTED_PROXY_EMAIL_HEADER)?.trim();
+  const name = getHeader(event, WG_ENV.TRUSTED_PROXY_NAME_HEADER)?.trim();
+
+  const result = await Database.users.loginWithTrustedHeader(
+    username,
+    username,
+    email || null,
+    name || username,
+    WG_ENV.TRUSTED_PROXY_DEFAULT_ROLE === 'admin' ? roles.ADMIN : roles.CLIENT
+  );
+
+  if (!result.success) {
+    // A blocked identity (disabled / already linked to another provider / TOTP
+    // required / auto-register disabled) must NOT establish a session. Fall
+    // through to the normal auth flow, which surfaces the appropriate error.
+    SERVER_DEBUG(
+      `Trusted-header SSO: login for '${username}' not established (${result.error})`
+    );
+    return;
+  }
+
+  const session = await useWGSession(event);
+  const data = await session.update({ userId: result.user.id });
+
+  SERVER_DEBUG(
+    `Trusted-header SSO: session ${data.id} established for ${result.user.id} (${result.user.username})`
+  );
+});

--- a/src/server/utils/config.ts
+++ b/src/server/utils/config.ts
@@ -64,7 +64,64 @@ export const WG_ENV = {
     oauthProviders?.find((p) => p === process.env.OAUTH_AUTO_LAUNCH) ?? null,
   /** Disable password authentication */
   DISABLE_PASSWORD_AUTH: process.env.DISABLE_PASSWORD_AUTH === 'true',
+  /**
+   * Trusted-header SSO (Culpur fork).
+   *
+   * When enabled, an already-authenticated upstream reverse proxy (e.g. an
+   * Authentik forward-auth outpost) may assert the caller's identity via a
+   * header. wg-easy then establishes a session for the matching user, reusing
+   * the OAuth account machinery (oauth_provider = 'trusted-header') and the
+   * OAUTH_AUTO_REGISTER gate to auto-provision when absent. DISABLED by default:
+   * stock behaviour is unchanged unless TRUSTED_PROXY_ENABLED is set.
+   */
+  TRUSTED_PROXY_ENABLED: process.env.TRUSTED_PROXY_ENABLED === 'true',
+  /**
+   * Shared secret the trusted proxy injects (PRIMARY trust factor). The feature
+   * fails closed if this is unset while enabled. In a shared-bridge / Docker
+   * SNAT topology this — not the source IP — is what proves a request came from
+   * the proxy, because every inbound connection is SNAT'd to the bridge gateway.
+   */
+  TRUSTED_PROXY_SECRET: process.env.TRUSTED_PROXY_SECRET ?? '',
+  /** Header the proxy uses to carry the shared secret. */
+  TRUSTED_PROXY_SECRET_HEADER: (
+    process.env.TRUSTED_PROXY_SECRET_HEADER ?? 'x-wg-proxy-secret'
+  ).toLowerCase(),
+  /** Header carrying the verified username, e.g. 'x-authentik-username'. */
+  TRUSTED_PROXY_HEADER: (
+    process.env.TRUSTED_PROXY_HEADER ?? 'x-authentik-username'
+  ).toLowerCase(),
+  /** Optional header carrying the verified email. */
+  TRUSTED_PROXY_EMAIL_HEADER: (
+    process.env.TRUSTED_PROXY_EMAIL_HEADER ?? 'x-authentik-email'
+  ).toLowerCase(),
+  /** Optional header carrying the display name. */
+  TRUSTED_PROXY_NAME_HEADER: (
+    process.env.TRUSTED_PROXY_NAME_HEADER ?? 'x-authentik-name'
+  ).toLowerCase(),
+  /**
+   * Optional comma-separated allowlist of proxy source IPs permitted to assert
+   * identity (defense-in-depth). Left empty when SNAT makes the peer IP
+   * non-discriminating; the shared secret remains the trust boundary.
+   */
+  TRUSTED_PROXY_IPS: (process.env.TRUSTED_PROXY_IPS ?? '')
+    .split(',')
+    .map((x) => x.trim())
+    .filter((x) => x.length > 0),
+  /** Role for auto-provisioned federated users: 'admin' or 'client' (default). */
+  TRUSTED_PROXY_DEFAULT_ROLE:
+    process.env.TRUSTED_PROXY_DEFAULT_ROLE === 'admin' ? 'admin' : 'client',
 };
+
+if (WG_ENV.TRUSTED_PROXY_ENABLED) {
+  SERVER_DEBUG(`
+Trusted-header SSO: Enabled${WG_ENV.TRUSTED_PROXY_SECRET ? '' : ' (NO SECRET — fails closed)'}
+Username header: ${WG_ENV.TRUSTED_PROXY_HEADER}
+Secret header: ${WG_ENV.TRUSTED_PROXY_SECRET_HEADER}
+Source IP allowlist: ${WG_ENV.TRUSTED_PROXY_IPS.length > 0 ? WG_ENV.TRUSTED_PROXY_IPS.join(', ') : 'None (secret-only)'}
+Auto register: ${WG_ENV.OAUTH_AUTO_REGISTER ? 'Enabled' : 'Disabled'}
+Default role: ${WG_ENV.TRUSTED_PROXY_DEFAULT_ROLE}
+`);
+}
 
 if (WG_ENV.OAUTH_PROVIDERS && WG_ENV.OAUTH_PROVIDERS.length > 0) {
   SERVER_DEBUG(`

--- a/src/server/utils/oauth.ts
+++ b/src/server/utils/oauth.ts
@@ -61,6 +61,23 @@ export const OAUTH_PROVIDERS = {
 
 export type OAUTH_PROVIDER = keyof typeof OAUTH_PROVIDERS;
 
+/**
+ * Pseudo-provider tag for trusted-header SSO (Culpur fork).
+ *
+ * This is NOT a click-to-login OAuth provider: it has no client id/secret and is
+ * deliberately absent from `OAUTH_PROVIDERS` so it never appears as a login
+ * button or in `/api/auth/methods`. It exists only as a value for the
+ * `oauth_provider` DB column so trusted-header identities are linked/looked up
+ * via the same account machinery as real OAuth users.
+ */
+export const TRUSTED_HEADER_PROVIDER = 'trusted-header' as const;
+
+/**
+ * Any value the `oauth_provider` DB column may hold: a real OAuth provider, or
+ * the trusted-header pseudo-provider.
+ */
+export type AUTH_PROVIDER = OAUTH_PROVIDER | typeof TRUSTED_HEADER_PROVIDER;
+
 export function isValidOauthProvider(
   provider: string
 ): provider is OAUTH_PROVIDER {


### PR DESCRIPTION
## Summary

Adds **optional trusted-header SSO** so wg-easy can run behind an authenticating reverse proxy (Authentik, Authelia, oauth2-proxy, …) and trust the identity the proxy has already verified — instead of showing its own login form to users who are already authenticated upstream.

When enabled, the proxy asserts the username via a header, and wg-easy establishes a normal session for that user, provisioning the account on first sight. This is a common request for teams that already run SSO and don't want a second, separate wg-easy credential.

**It is disabled by default. Stock behaviour is completely unchanged unless `TRUSTED_PROXY_ENABLED=true` is set.**

## How it works

Auth still funnels through the existing `getCurrentUser()` chokepoint and the normal stateless session cookie. A small Nitro middleware (`server/middleware/trustedAuth.ts`) runs before routes: when enabled and the request proves it came from the trusted proxy, it reads the identity header, resolves or provisions the user, and calls `useWGSession().update({ userId })`. Everything downstream (RBAC via `definePermissionEventHandler`) then works with zero changes to route handlers.

## Security model

A raw client can forge any header, so the trust boundary is a **shared secret the proxy injects** (`TRUSTED_PROXY_SECRET`), verified with a constant-time compare. The feature **fails closed** if enabled without a secret. An optional source-IP allowlist (`TRUSTED_PROXY_IPS`) is available as defense-in-depth, but it is intentionally optional because container NAT often rewrites the peer to a gateway address, making IP alone non-discriminating — so the secret is the real gate.

Provisioned SSO users have no local password (`password` is now nullable, `auth_provider` distinguishes them) and therefore **cannot** authenticate via the password/Basic path — `isPasswordValid` fails closed on a null hash.

## Changes

- `server/middleware/trustedAuth.ts` (new) — the trust gate + session establishment.
- `server/utils/config.ts` — new `TRUSTED_PROXY_*` env (all off/empty by default).
- `server/database/repositories/user/service.ts` — `getOrCreateExternal()` for password-less federated users (never escalates role/enabled on existing users; refreshes email/name).
- `server/database/repositories/user/schema.ts` + migration `0005` — `password` nullable, add `auth_provider` (existing users backfilled to `local`).
- `server/utils/password.ts` — `isPasswordValid` accepts a nullable hash and fails closed.
- Docs: `advanced/config/optional-config.md` table + security note, `.env.example`, and a commented block in `docker-compose.yml`.

## Config

See the new section in `docs/advanced/config/optional-config.md`. Minimal example:

```env
TRUSTED_PROXY_ENABLED=true
TRUSTED_PROXY_SECRET=<openssl rand -hex 32>   # the proxy must inject this
TRUSTED_PROXY_HEADER=x-authentik-username     # or x-forwarded-user, etc.
TRUSTED_PROXY_DEFAULT_ROLE=client             # or admin
```

## Testing

Built from source and verified end-to-end behind an Authentik forward-auth outpost:
- Valid secret + username header → user auto-provisioned, session established, lands straight in the dashboard.
- Wrong/missing secret → rejected (fails closed), falls back to the normal login form.
- Feature disabled → header ignored entirely, stock behaviour.
- Migration applies cleanly to an existing DB; existing users backfill to `auth_provider=local` and keep working with password login.

Happy to adjust naming, defaults, or split this differently — feedback welcome.
