### PR TITLE
fix: add checks while applying firewall changes if IPv6 is disabled

### DIFF
--- a/src/server/utils/firewall.ts
+++ b/src/server/utils/firewall.ts
@@ -164,32 +164,38 @@ export const firewall = {
   /**
    * Initialize the custom chain if it doesn't exist
    */
-  async initChain(interfaceName: string): Promise<void> {
+  async initChain(interfaceName: string, enableIpv6: boolean): Promise<void> {
     FW_DEBUG(
       `Initializing firewall chain ${CHAIN_NAME} for interface ${interfaceName}`
     );
 
     // Create chain if not exists (iptables returns error if exists, so we ignore)
     await exec(`iptables -N ${CHAIN_NAME} 2>/dev/null || true`);
-    await exec(`ip6tables -N ${CHAIN_NAME} 2>/dev/null || true`);
+    if (enableIpv6) {
+      await exec(`ip6tables -N ${CHAIN_NAME} 2>/dev/null || true`);
+    }
 
     // Ensure chain is referenced from FORWARD (if not already)
     // Insert at position 1 to process before generic ACCEPT rules
     await exec(
       `iptables -C FORWARD -i ${interfaceName} -j ${CHAIN_NAME} 2>/dev/null || iptables -I FORWARD 1 -i ${interfaceName} -j ${CHAIN_NAME}`
     );
-    await exec(
-      `ip6tables -C FORWARD -i ${interfaceName} -j ${CHAIN_NAME} 2>/dev/null || ip6tables -I FORWARD 1 -i ${interfaceName} -j ${CHAIN_NAME}`
-    );
+    if (enableIpv6) {
+      await exec(
+        `ip6tables -C FORWARD -i ${interfaceName} -j ${CHAIN_NAME} 2>/dev/null || ip6tables -I FORWARD 1 -i ${interfaceName} -j ${CHAIN_NAME}`
+      );
+    }
   },
 
   /**
    * Flush all rules in the custom chain
    */
-  async flushChain(): Promise<void> {
+  async flushChain(enableIpv6: boolean): Promise<void> {
     FW_DEBUG(`Flushing firewall chain ${CHAIN_NAME}`);
     await exec(`iptables -F ${CHAIN_NAME} 2>/dev/null || true`);
-    await exec(`ip6tables -F ${CHAIN_NAME} 2>/dev/null || true`);
+    if (enableIpv6) {
+      await exec(`ip6tables -F ${CHAIN_NAME} 2>/dev/null || true`);
+    }
   },
 
   /**
@@ -245,7 +251,7 @@ export const firewall = {
   ): Promise<void> {
     if (!wgInterface.firewallEnabled) {
       FW_DEBUG('Firewall filtering disabled, removing any existing rules');
-      await this.removeFiltering(wgInterface.name);
+      await this.removeFiltering(wgInterface.name, enableIpv6);
       return;
     }
 
@@ -262,10 +268,10 @@ export const firewall = {
       FW_DEBUG('Rebuilding firewall rules...');
 
       // Initialize chain structure
-      await this.initChain(wgInterface.name);
+      await this.initChain(wgInterface.name, enableIpv6);
 
       // Flush existing rules
-      await this.flushChain();
+      await this.flushChain(enableIpv6);
 
       // Apply rules for each enabled client
       for (const client of clients) {
@@ -299,22 +305,26 @@ export const firewall = {
   /**
    * Remove all firewall filtering (when feature is disabled)
    */
-  async removeFiltering(interfaceName: string): Promise<void> {
+  async removeFiltering(interfaceName: string, enableIpv6: boolean): Promise<void> {
     FW_DEBUG(`Removing firewall filtering for interface ${interfaceName}`);
 
     // Remove jump rules from FORWARD chain
     await exec(
       `iptables -D FORWARD -i ${interfaceName} -j ${CHAIN_NAME} 2>/dev/null || true`
     );
-    await exec(
-      `ip6tables -D FORWARD -i ${interfaceName} -j ${CHAIN_NAME} 2>/dev/null || true`
-    );
+    if (enableIpv6) {
+      await exec(
+        `ip6tables -D FORWARD -i ${interfaceName} -j ${CHAIN_NAME} 2>/dev/null || true`
+      );
+    }
 
     // Flush and delete the chain
     await exec(`iptables -F ${CHAIN_NAME} 2>/dev/null || true`);
-    await exec(`ip6tables -F ${CHAIN_NAME} 2>/dev/null || true`);
     await exec(`iptables -X ${CHAIN_NAME} 2>/dev/null || true`);
-    await exec(`ip6tables -X ${CHAIN_NAME} 2>/dev/null || true`);
+    if (enableIpv6) {
+      await exec(`ip6tables -F ${CHAIN_NAME} 2>/dev/null || true`);
+      await exec(`ip6tables -X ${CHAIN_NAME} 2>/dev/null || true`);
+    }
   },
 
   /**


### PR DESCRIPTION
## Description

First of all, thanks for adding the per-client firewall option to wg-easy. I've been waiting for an easy way to configure this on the server side for a long time. Not having to manually mess around with `iptables` command is a blessing. :+1: 

Unfortunately, I found out that `ip6tables` commands are being executed even when IPv6 support is disabled via the environment variable `DISABLE_IPV6=true`. I'm a bit surprised that I seem to be the first one that found this issue.

## Motivation and Context
I noticed that hitting the save button in the admin panel failed with an error after "Enable Per-Client Firewall" was selected.
The logs revealed the following error messages:
```
2026-07-18T12:11:45.233Z CMD $ iptables --version
2026-07-18T12:11:45.236Z Firewall iptables is available
2026-07-18T12:11:45.236Z Firewall IPv6 disabled, skipping ip6tables check
2026-07-18T12:11:45.236Z WireGuard Applying firewall rules...
2026-07-18T12:11:45.237Z Firewall Rebuilding firewall rules...
2026-07-18T12:11:45.237Z Firewall Initializing firewall chain WG_CLIENTS for interface wg0
2026-07-18T12:11:45.237Z CMD $ iptables -N WG_CLIENTS 2>/dev/null || true
2026-07-18T12:11:45.241Z CMD $ ip6tables -N WG_CLIENTS 2>/dev/null || true
2026-07-18T12:11:45.245Z CMD $ iptables -C FORWARD -i wg0 -j WG_CLIENTS 2>/dev/null || iptables -I FORWARD 1 -i wg0 -j WG_CLIENTS
2026-07-18T12:11:45.249Z CMD $ ip6tables -C FORWARD -i wg0 -j WG_CLIENTS 2>/dev/null || ip6tables -I FORWARD 1 -i wg0 -j WG_CLIENTS
[unhandledRejection] Error: Command failed: ip6tables -C FORWARD -i wg0 -j WG_CLIENTS 2>/dev/null || ip6tables -I FORWARD 1 -i wg0 -j WG_CLIENTS
modprobe: FATAL: Module ip6_tables not found in directory /lib/modules/6.8.0-100-generic
ip6tables v1.8.11 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)
Perhaps ip6tables or your kernel needs to be upgraded.
  at genericNodeError (node:internal/errors:985:15)
  at wrappedFn (node:internal/errors:539:14)
  at ChildProcess.exithandler (node:child_process:417:12)
  at ChildProcess.emit (node:events:509:28)
  at maybeClose (node:internal/child_process:1124:16)
  at Socket.<anonymous> (node:internal/child_process:481:11)
  at Socket.emit (node:events:509:28)
  at Pipe.<anonymous> (node:net:350:12) {
code: 3,
killed: false,
signal: null,
cmd: 'ip6tables -C FORWARD -i wg0 -j WG_CLIENTS 2>/dev/null || ip6tables -I FORWARD 1 -i wg0 -j WG_CLIENTS'
}
```

After looking through the source code in https://github.com/wg-easy/wg-easy/blob/master/src/server/utils/firewall.ts I found a few lines with missing checks if IPv6 is disabled before running an `ip6tables` command.

## How has this been tested?
I've tested it locally, comparing the `ghcr.io/wg-easy/wg-easy:15.3.0` image with an image that included the changes in this PR. Toggling the "Enable Per-Client Firewall" is confirmed with "Success - Saved" now.
With my changes the logs show no calls to `ip6tables` and no errors anymore:
```
2026-07-18T14:04:10.791Z Firewall Rebuilding firewall rules...
2026-07-18T14:04:10.791Z Firewall Initializing firewall chain WG_CLIENTS for interface wg0
2026-07-18T14:04:10.791Z CMD $ iptables -N WG_CLIENTS 2>/dev/null || true
2026-07-18T14:04:10.795Z CMD $ iptables -C FORWARD -i wg0 -j WG_CLIENTS 2>/dev/null || iptables -I FORWARD 1 -i wg0 -j WG_CLIENTS
2026-07-18T14:04:10.798Z Firewall Flushing firewall chain WG_CLIENTS
2026-07-18T14:04:10.798Z CMD $ iptables -F WG_CLIENTS 2>/dev/null || true
2026-07-18T14:04:10.801Z Firewall Applying firewall rules for client Foobar (1): 0.0.0.0/0, ::/0
2026-07-18T14:04:10.801Z CMD $ iptables -A WG_CLIENTS -s 10.17.0.1 -d 0.0.0.0/0 -m comment --comment "client 1: Foobar" -j ACCEPT
2026-07-18T14:04:10.805Z Firewall Applying firewall rules for client work (2): 0.0.0.0/0, ::/0
2026-07-18T14:04:10.824Z CMD $ iptables -A WG_CLIENTS -j DROP
2026-07-18T14:04:10.827Z Firewall Firewall rules rebuilt successfully
```
```
2026-07-18T14:09:15.743Z Firewall Firewall filtering disabled, removing any existing rules
2026-07-18T14:09:15.743Z Firewall Removing firewall filtering for interface wg0
2026-07-18T14:09:15.743Z CMD $ iptables -D FORWARD -i wg0 -j WG_CLIENTS 2>/dev/null || true
2026-07-18T14:09:15.747Z CMD $ iptables -F WG_CLIENTS 2>/dev/null || true
2026-07-18T14:09:15.750Z CMD $ iptables -X WG_CLIENTS 2>/dev/null || true
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

I'm not a TypeScript programmer, but I tried to stick to the existing code formatting. Please let me know if this patch can be improved somehow. 