### PR TITLE
fix: escape Prometheus label values

### DIFF
--- a/src/server/routes/metrics/prometheus.get.ts
+++ b/src/server/routes/metrics/prometheus.get.ts
@@ -3,6 +3,7 @@ import { setHeader } from 'h3';
 import Database from '#server/utils/Database';
 import WireGuard from '#server/utils/WireGuard';
 import { defineMetricsHandler } from '#server/utils/handler';
+import { formatPrometheusLabels } from '#server/utils/prometheus';
 import { isPeerConnected } from '#shared/utils/time';
 
 export default defineMetricsHandler('prometheus', async ({ event }) => {
@@ -27,7 +28,13 @@ async function getPrometheusResponse() {
       wireguardConnectedPeersCount++;
     }
 
-    const id = `interface="${wgInterface.name}",enabled="${client.enabled}",ipv4Address="${client.ipv4Address}",ipv6Address="${client.ipv6Address}",name="${client.name}"`;
+    const id = formatPrometheusLabels({
+      interface: wgInterface.name,
+      enabled: client.enabled,
+      ipv4Address: client.ipv4Address,
+      ipv6Address: client.ipv6Address,
+      name: client.name,
+    });
 
     wireguardSentBytes.push(
       `wireguard_sent_bytes{${id}} ${client.transferTx ?? 0}`
@@ -41,7 +48,7 @@ async function getPrometheusResponse() {
     );
   }
 
-  const id = `interface="${wgInterface.name}"`;
+  const id = formatPrometheusLabels({ interface: wgInterface.name });
 
   const returnText = [
     '# HELP wireguard_configured_peers',

--- a/src/server/utils/prometheus.ts
+++ b/src/server/utils/prometheus.ts
@@ -1,0 +1,17 @@
+export function escapePrometheusLabelValue(value: string): string {
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('\n', '\\n')
+    .replaceAll('"', '\\"');
+}
+
+export function formatPrometheusLabels(
+  labels: Record<string, string | number | boolean>
+): string {
+  return Object.entries(labels)
+    .map(
+      ([name, value]) =>
+        `${name}="${escapePrometheusLabelValue(String(value))}"`
+    )
+    .join(',');
+}

--- a/src/test/unit/prometheus.spec.ts
+++ b/src/test/unit/prometheus.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  escapePrometheusLabelValue,
+  formatPrometheusLabels,
+} from '#server/utils/prometheus';
+
+describe('Prometheus label formatting', () => {
+  test('escapes quotes, backslashes, and newlines in label values', () => {
+    expect(escapePrometheusLabelValue('vpn"client')).toBe('vpn\\"client');
+    expect(escapePrometheusLabelValue('path\\client')).toBe('path\\\\client');
+    expect(escapePrometheusLabelValue('line one\nline two')).toBe(
+      'line one\\nline two'
+    );
+  });
+
+  test('formats escaped values without changing scalar values', () => {
+    expect(
+      formatPrometheusLabels({
+        interface: 'wg"0',
+        enabled: true,
+        name: 'home\\office\npeer',
+      })
+    ).toBe('interface="wg\\"0",enabled="true",name="home\\\\office\\npeer"');
+  });
+});


### PR DESCRIPTION
## Description

Adds Prometheus text-format label escaping and uses it for every dynamic label value emitted by the metrics endpoint. Backslashes, double quotes, and newlines now follow Prometheus escaping rules.

## Motivation and Context

Client names may legitimately contain double quotes. Interpolating those names directly into a label value produced an invalid metrics document, causing Prometheus to reject the entire scrape.

Closes #2699.

## How has this been tested?

- Added focused unit tests for quotes, backslashes, newlines, booleans, and complete label sets.
- Full unit suite: 31 passed.
- ESLint and Nuxt typecheck passed locally and on Ubuntu 24.04 ARM64 in a Node 24 container.
- A generated sample containing all three escaped characters passed `promtool check metrics` on the test host; the equivalent pre-fix sample failed parsing.

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

AI assistance was used during review, implementation, and drafting. The resulting code and tests were reviewed and verified against the reported reproduction.
