### PR TITLE
perf: merge client status in linear time

### DIFF
--- a/src/server/utils/WireGuard.ts
+++ b/src/server/utils/WireGuard.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import { createDebug } from 'obug';
 
 import Database from '#server/utils/Database';
+import { mergeClientStatuses } from '#server/utils/clientStatus';
 import { OLD_ENV, WG_ENV } from '#server/utils/config';
 import { firewall } from '#server/utils/firewall';
 import { encodeQRCode } from '#server/utils/qr';
@@ -103,21 +104,7 @@ class WireGuard {
 
     // Loop WireGuard status
     const dump = await wg.dump(wgInterface.name);
-    dump.forEach(
-      ({ publicKey, latestHandshakeAt, endpoint, transferRx, transferTx }) => {
-        const client = clients.find((client) => client.publicKey === publicKey);
-        if (!client) {
-          return;
-        }
-
-        client.latestHandshakeAt = latestHandshakeAt;
-        client.endpoint = endpoint;
-        client.transferRx = transferRx;
-        client.transferTx = transferTx;
-      }
-    );
-
-    return clients;
+    return mergeClientStatuses(clients, dump);
   }
 
   async dumpByPublicKey(publicKey: string) {
@@ -146,21 +133,7 @@ class WireGuard {
 
     // Loop WireGuard status
     const dump = await wg.dump(wgInterface.name);
-    dump.forEach(
-      ({ publicKey, latestHandshakeAt, endpoint, transferRx, transferTx }) => {
-        const client = clients.find((client) => client.publicKey === publicKey);
-        if (!client) {
-          return;
-        }
-
-        client.latestHandshakeAt = latestHandshakeAt;
-        client.endpoint = endpoint;
-        client.transferRx = transferRx;
-        client.transferTx = transferTx;
-      }
-    );
-
-    return clients;
+    return mergeClientStatuses(clients, dump);
   }
 
   async getClientConfiguration({ clientId }: { clientId: ID }) {

--- a/src/server/utils/clientStatus.ts
+++ b/src/server/utils/clientStatus.ts
@@ -1,0 +1,30 @@
+type StatusFields = {
+  publicKey: string;
+  latestHandshakeAt: Date | null;
+  endpoint: string | null;
+  transferRx: number | null;
+  transferTx: number | null;
+};
+
+export function mergeClientStatuses<T extends StatusFields>(
+  clients: T[],
+  statuses: readonly StatusFields[]
+): T[] {
+  const clientsByPublicKey = new Map(
+    clients.map((client) => [client.publicKey, client])
+  );
+
+  for (const status of statuses) {
+    const client = clientsByPublicKey.get(status.publicKey);
+    if (!client) {
+      continue;
+    }
+
+    client.latestHandshakeAt = status.latestHandshakeAt;
+    client.endpoint = status.endpoint;
+    client.transferRx = status.transferRx;
+    client.transferTx = status.transferTx;
+  }
+
+  return clients;
+}

--- a/src/test/unit/clientStatus.spec.ts
+++ b/src/test/unit/clientStatus.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest';
+
+import { mergeClientStatuses } from '#server/utils/clientStatus';
+
+describe('mergeClientStatuses', () => {
+  test('merges matching status records by public key', () => {
+    const clients = [
+      {
+        id: 1,
+        publicKey: 'first',
+        latestHandshakeAt: null,
+        endpoint: null,
+        transferRx: null,
+        transferTx: null,
+      },
+      {
+        id: 2,
+        publicKey: 'second',
+        latestHandshakeAt: null,
+        endpoint: null,
+        transferRx: null,
+        transferTx: null,
+      },
+    ];
+    const handshake = new Date('2026-07-20T00:00:00Z');
+
+    const result = mergeClientStatuses(clients, [
+      {
+        publicKey: 'second',
+        latestHandshakeAt: handshake,
+        endpoint: '192.0.2.1:51820',
+        transferRx: 100,
+        transferTx: 200,
+      },
+      {
+        publicKey: 'unknown',
+        latestHandshakeAt: null,
+        endpoint: null,
+        transferRx: 0,
+        transferTx: 0,
+      },
+    ]);
+
+    expect(result).toBe(clients);
+    expect(result[0]?.endpoint).toBeNull();
+    expect(result[1]).toMatchObject({
+      latestHandshakeAt: handshake,
+      endpoint: '192.0.2.1:51820',
+      transferRx: 100,
+      transferTx: 200,
+    });
+  });
+});


### PR DESCRIPTION
## Description

Indexes fetched clients by public key once, then merges WireGuard status records through constant-time map lookups. Both user-scoped and all-client list paths use the same tested helper.

## Motivation and Context

Each status record previously performed a linear `clients.find(...)`. With similarly sized client and dump arrays, every refresh therefore performed quadratic work; the UI polls this path every second.

Closes #2700.

## How has this been tested?

- Added a unit test covering matched and unknown status records while preserving the existing return object.
- Full unit suite: 30 passed.
- ESLint and Nuxt typecheck passed locally and on Ubuntu 24.04 ARM64 in a Node 24 container.
- Test-host benchmark at 20,000 clients: 1,203.49 ms before, 6.88 ms after (same ARM64 VPS; representative runs).

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

AI assistance was used during review, implementation, and drafting. The resulting code and tests were reviewed and verified against the reported reproduction.
