### PR TITLE
fix(cli): bundle JS dependencies into cli.mjs

### DIFF
--- a/src/cli/build.js
+++ b/src/cli/build.js
@@ -1,58 +1,18 @@
 // @ts-check
 
-import { writeFile, mkdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-
 import esbuild from 'esbuild';
 
-const isTrace =
-  process.argv.slice(2).findIndex((arg) => arg === '--trace') !== -1;
+// Native modules that cannot be bundled and are handled separately in Docker
+const external = ['argon2', '@libsql/client'];
 
-/**
- * Writes files with needed imports to `../node_modules/.cache/wg-easy/trace.mjs`
- *
- * @param {import('esbuild').Metafile} metafile
- */
-async function writeTrace(metafile) {
-  const paths = [
-    ...new Set(
-      Object.values(metafile.outputs).flatMap((v) =>
-        v.imports.map((v) => v.path)
-      )
-    ),
-  ];
-  const imports = paths.map((v) => `import '${v}';`).join('\n');
-
-  const folderUrl = new URL('../node_modules/.cache/wg-easy/', import.meta.url);
-  const folder = fileURLToPath(folderUrl);
-  const filePath = fileURLToPath(new URL('./trace.mjs', folderUrl));
-
-  await mkdir(folder, { recursive: true });
-  await writeFile(filePath, imports);
-}
-
-function getOverrides() {
-  if (isTrace) {
-    return {
-      outfile: undefined,
-      write: false,
-    };
-  }
-  return {};
-}
-
-const result = await esbuild.build({
+await esbuild.build({
   entryPoints: [fileURLToPath(new URL('./index.ts', import.meta.url))],
   bundle: true,
   outfile: fileURLToPath(new URL('../.output/server/cli.mjs', import.meta.url)),
   platform: 'node',
   format: 'esm',
-  packages: 'external',
+  target: 'node24',
+  external,
   logLevel: 'info',
-  metafile: true,
-  ...getOverrides(),
 });
-
-if (isTrace) {
-  await writeTrace(result.metafile);
-}

--- a/src/nuxt.config.ts
+++ b/src/nuxt.config.ts
@@ -165,13 +165,6 @@ export default defineNuxtConfig({
         target: 'node24',
       },
     },
-    externals: {
-      traceInclude: [
-        fileURLToPath(
-          new URL('./node_modules/.cache/wg-easy/trace.mjs', import.meta.url)
-        ),
-      ],
-    },
   },
   alias: {
     '#db': fileURLToPath(new URL('./server/database/', import.meta.url)),

--- a/src/package.json
+++ b/src/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm cli:trace && nuxt build && pnpm cli:build",
+    "build": "nuxt build && pnpm cli:build",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
@@ -16,7 +16,6 @@
     "typecheck": "nuxt typecheck",
     "check:all": "pnpm typecheck && pnpm lint && pnpm format:check && pnpm build",
     "db:generate": "drizzle-kit generate",
-    "cli:trace": "node cli/build.js --trace",
     "cli:build": "node cli/build.js",
     "cli:dev": "tsx cli/index.ts",
     "test:unit": "vitest run --project unit"


### PR DESCRIPTION
## Description

This PR fixes an issue where running CLI commands (such as `cli db:admin:reset`) inside the production Docker image fails with `ERR_MODULE_NOT_FOUND` due to missing packages (`citty`, `consola`).

The previous attempt to resolve this (#2683) relied on Nitro's `traceInclude` mechanism. However, this approach proved fragile because the multi-stage Dockerfile prunes `node_modules` aggressively in the final stage.

Instead of relying on dependency tracing, this change configures `esbuild` to **bundle all pure JS dependencies directly into `cli.mjs`**.

Key technical changes:
- `src/cli/build.js`: Removed `packages: 'external'` and the `--trace` logic. Enabled `bundle: true` for all JS dependencies while keeping native binary modules (`argon2`, `@libsql/client`) external.
- `src/nuxt.config.ts`: Removed obsolete `nitro.externals.traceInclude` config.
- `src/package.json`: Simplified the `build` script by removing the `cli:trace` step.

## Motivation and Context

- Fixes `ERR_MODULE_NOT_FOUND` when executing `cli db:admin:reset` in the production container.
- Related to #2682.
- Ensures the CLI tool is self-contained and robust against Docker `node_modules` pruning.

## How has this been tested?

1. Built a local Docker image using `docker build -t wg-easy-local .`.
2. Verified that `docker run --rm wg-easy-local cli --help` and `docker run --rm wg-easy-local cli db:admin:reset --help` execute successfully without any missing package errors.
3. Verified that the main Web UI server still compiles and boots correctly (`Listening on http://0.0.0.0:51821`).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (change which does not alter existing functionality)
- [ ] Documentation (changes to documentation only)

## Checklist:

- [x] I have reviewed my own changes.
- [x] My code follows the code style of this project.
- [ ] I have added or updated tests where appropriate.
- [x] My changes do not include unrelated modifications.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## AI Disclosure:

Google Gemini was used to analyze the build scripts, diagnose why the previous tracing fix (#2683) failed in multi-stage Docker builds, and draft the PR. All proposed code changes were manually reviewed, compiled, and tested in a local Docker environment before submitting.