### PR TITLE
chore: remove timeago

### DIFF
--- a/src/app/components/ClientCard/LastSeen.vue
+++ b/src/app/components/ClientCard/LastSeen.vue
@@ -3,14 +3,26 @@
     v-if="client.latestHandshakeAt"
     :title="$t('client.lastSeen') + $d(new Date(client.latestHandshakeAt))"
   >
-    {{ timeago(new Date(client.latestHandshakeAt)) }}
+    {{ lastSeen }}
   </span>
 </template>
 
 <script setup lang="ts">
-import { format as timeago } from 'timeago.js';
-
-defineProps<{
+const props = defineProps<{
   client: LocalClient;
 }>();
+
+const { localeProperties } = useI18n();
+
+const lastSeen = computed(() => {
+  const now = Date.now();
+
+  return formatTimeAgoIntl(
+    new Date(props.client.latestHandshakeAt ?? now),
+    {
+      locale: localeProperties.value.language,
+    },
+    now
+  );
+});
 </script>

--- a/src/package.json
+++ b/src/package.json
@@ -52,7 +52,6 @@
     "radix-vue": "^1.9.17",
     "semver": "^7.8.5",
     "tailwindcss": "^3.4.19",
-    "timeago.js": "^4.0.2",
     "vue": "latest",
     "vue3-apexcharts": "^1.11.1",
     "zod": "^4.4.3"

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19(tsx@4.23.12)(yaml@2.9.0)
-      timeago.js:
-        specifier: ^4.0.2
-        version: 4.0.2
       vue:
         specifier: latest
         version: 3.5.41(typescript@6.0.3)
@@ -5348,9 +5345,6 @@ packages:
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
-
-  timeago.js@4.0.2:
-    resolution: {integrity: sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -11553,8 +11547,6 @@ snapshots:
   time-span@5.1.0:
     dependencies:
       convert-hrtime: 5.0.0
-
-  timeago.js@4.0.2: {}
 
   tiny-invariant@1.3.3: {}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

replace timeago.js with `formatTimeAgoIntl` from vueuse

## Motivation and Context

timeago is very old

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (change which does not alter existing functionality)
- [ ] Documentation (changes to documentation only)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have reviewed my own changes.
- [x] My code follows the code style of this project.
- [ ] I have added or updated tests where appropriate.
- [x] My changes do not include unrelated modifications.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
