### PR TITLE
Add FlClash/Mihomo split-routing profile export

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You have found the easiest way to install & manage WireGuard on any Linux host!
 - List, create, edit, delete, enable & disable clients.
 - Show a client's QR code.
 - Download a client's configuration file.
+- Export a FlClash/Mihomo profile for split routing through WireGuard.
 - Statistics for which clients are connected.
 - Tx/Rx charts for each connected client.
 - Gravatar support.

--- a/docs/content/advanced/config/optional-config.md
+++ b/docs/content/advanced/config/optional-config.md
@@ -4,14 +4,29 @@ title: Optional Configuration
 
 You can set these environment variables to configure the container. They are not required, but can be useful in some cases.
 
-| Env                     | Default   | Example                     | Description                                                     |
-| ----------------------- | --------- | --------------------------- | --------------------------------------------------------------- |
-| `PORT`                  | `51821`   | `6789`                      | TCP port for Web UI.                                            |
-| `HOST`                  | `0.0.0.0` | `localhost`                 | IP address web UI binds to.                                     |
-| `INSECURE`              | `false`   | `true`                      | If access over http is allowed                                  |
-| `DISABLE_IPV6`          | `false`   | `true`                      | If IPv6 support should be disabled                              |
-| `DISABLE_VERSION_CHECK` | `false`   | `true`                      | If wg-easy should check for new updates                         |
-| `TRUSTED_PROXIES`       |           | `172.18.0.2,fd00:1234::/64` | Proxy IP addresses or CIDRs allowed to forward the request host |
+| Env                           | Default   | Example                     | Description                                                              |
+| ----------------------------- | --------- | --------------------------- | ------------------------------------------------------------------------ |
+| `PORT`                        | `51821`   | `6789`                      | TCP port for Web UI.                                                     |
+| `HOST`                        | `0.0.0.0` | `localhost`                 | IP address web UI binds to.                                              |
+| `INSECURE`                    | `false`   | `true`                      | If access over http is allowed                                           |
+| `DISABLE_IPV6`                | `false`   | `true`                      | If IPv6 support should be disabled                                       |
+| `DISABLE_VERSION_CHECK`       | `false`   | `true`                      | If wg-easy should check for new updates                                  |
+| `TRUSTED_PROXIES`             |           | `172.18.0.2,fd00:1234::/64` | Proxy IP addresses or CIDRs allowed to forward the request host          |
+| `FLCLASH_REMOTE_CIDRS`        |           | `192.168.1.0/24,fd00::/64`  | Additional remote networks routed through the generated FlClash profile  |
+| `FLCLASH_ENDPOINT_IP_VERSION` | `dual`    | `ipv6-prefer`               | Endpoint resolution mode used by the generated FlClash WireGuard profile |
+
+## FlClash profile export
+
+Each client card includes an **FC** download button. It generates a Mihomo
+profile that sends the WireGuard tunnel networks and any networks listed in
+`FLCLASH_REMOTE_CIDRS` through WireGuard, routes Chinese destinations directly,
+and routes remaining traffic through WireGuard. Multiple IPv4 or IPv6 CIDRs can
+be separated by commas or spaces.
+
+`FLCLASH_ENDPOINT_IP_VERSION` accepts `dual`, `ipv4`, `ipv6`, `ipv4-prefer`, or
+`ipv6-prefer`. Generated files contain the client's private key and are returned
+with no-store response headers; treat them like regular WireGuard client
+configurations.
 
 ## Trusted Proxies
 

--- a/src/app/components/ClientCard/Config.vue
+++ b/src/app/components/ClientCard/Config.vue
@@ -1,12 +1,23 @@
 <template>
-  <a
-    :href="'/api/client/' + client.id + '/configuration'"
-    download
-    class="inline-block rounded bg-gray-100 p-2 align-middle transition hover:bg-red-800 hover:text-white dark:bg-neutral-600 dark:text-neutral-300 dark:hover:bg-red-800 dark:hover:text-white"
-    :title="$t('client.downloadConfig')"
-  >
-    <IconsDownload class="w-5" />
-  </a>
+  <span class="inline-flex items-center gap-2" role="group">
+    <a
+      :href="`/api/client/${client.id}/configuration`"
+      download
+      class="inline-block rounded bg-gray-100 p-2 align-middle transition hover:bg-red-800 hover:text-white dark:bg-neutral-600 dark:text-neutral-300 dark:hover:bg-red-800 dark:hover:text-white"
+      :title="$t('client.downloadConfig')"
+    >
+      <IconsDownload class="w-5" />
+    </a>
+    <a
+      :href="`/api/client/${client.id}/configuration?format=flclash`"
+      download
+      class="inline-flex h-9 min-w-9 items-center justify-center rounded bg-sky-100 px-2 text-xs font-bold text-sky-800 transition hover:bg-sky-700 hover:text-white dark:bg-sky-950 dark:text-sky-200 dark:hover:bg-sky-700 dark:hover:text-white"
+      :title="`FlClash: ${$t('client.downloadConfig')}`"
+      :aria-label="`FlClash: ${$t('client.downloadConfig')}`"
+    >
+      <span aria-hidden="true">FC</span>
+    </a>
+  </span>
 </template>
 
 <script setup lang="ts">

--- a/src/server/api/client/[clientId]/configuration.get.ts
+++ b/src/server/api/client/[clientId]/configuration.get.ts
@@ -1,9 +1,16 @@
-import { createError, getValidatedRouterParams, setHeader } from 'h3';
+import { createError, getQuery, getValidatedRouterParams, setHeader } from 'h3';
 
 import Database from '#server/utils/Database';
 import WireGuard from '#server/utils/WireGuard';
 import { definePermissionEventHandler } from '#server/utils/handler';
 import { validateZod } from '#server/utils/types';
+import { WG_ENV } from '#server/utils/config';
+import {
+  generateFlClashConfig,
+  parseFlClashEndpointIpVersion,
+  parseFlClashRemoteCidrs,
+  parseWireGuardClientConfig,
+} from '#server/utils/flClash';
 import { ClientGetSchema } from '#db/repositories/client/types';
 
 export default definePermissionEventHandler(
@@ -25,11 +32,51 @@ export default definePermissionEventHandler(
     }
 
     const config = await WireGuard.getClientConfiguration({ clientId });
+    const filename = WireGuard.cleanClientFilename(client.name) || clientId;
+
+    if (getQuery(event).format === 'flclash') {
+      try {
+        const wgInterface = await Database.interfaces.get();
+        const parsedConfig = parseWireGuardClientConfig(config);
+        const hasIpv6Tunnel =
+          !WG_ENV.DISABLE_IPV6 &&
+          parsedConfig.ipv6Address !== undefined &&
+          parsedConfig.allowedIps.includes('::/0');
+        const remoteCidrs = [
+          wgInterface.ipv4Cidr,
+          ...(hasIpv6Tunnel ? [wgInterface.ipv6Cidr] : []),
+          ...(process.env.FLCLASH_REMOTE_CIDRS
+            ? parseFlClashRemoteCidrs(process.env.FLCLASH_REMOTE_CIDRS)
+            : []),
+        ];
+        const profile = generateFlClashConfig(config, {
+          remoteCidrs,
+          endpointIpVersion: parseFlClashEndpointIpVersion(
+            process.env.FLCLASH_ENDPOINT_IP_VERSION || 'dual'
+          ),
+        });
+
+        setHeader(
+          event,
+          'Content-Disposition',
+          `attachment; filename="${filename}-flclash.yaml"`
+        );
+        setHeader(event, 'Content-Type', 'application/yaml; charset=utf-8');
+        setHeader(event, 'Cache-Control', 'private, no-store, max-age=0');
+        setHeader(event, 'X-Content-Type-Options', 'nosniff');
+        return profile;
+      } catch {
+        throw createError({
+          statusCode: 500,
+          statusMessage: 'Unable to generate FlClash configuration',
+        });
+      }
+    }
 
     setHeader(
       event,
       'Content-Disposition',
-      `attachment; filename="${WireGuard.cleanClientFilename(client.name) || clientId}.conf"`
+      `attachment; filename="${filename}.conf"`
     );
 
     setHeader(event, 'Content-Type', 'application/octet-stream');

--- a/src/server/utils/flClash.ts
+++ b/src/server/utils/flClash.ts
@@ -1,0 +1,482 @@
+import { isIP } from 'node:net';
+
+import isCidr from 'is-cidr';
+
+const ENDPOINT_IP_VERSIONS = [
+  'dual',
+  'ipv4',
+  'ipv6',
+  'ipv4-prefer',
+  'ipv6-prefer',
+] as const;
+
+export type FlClashEndpointIpVersion = (typeof ENDPOINT_IP_VERSIONS)[number];
+
+export type FlClashOptions = {
+  remoteCidrs: string[];
+  endpointIpVersion: FlClashEndpointIpVersion;
+};
+
+type WireGuardEndpoint = {
+  server: string;
+  port: number;
+};
+
+export type ParsedWireGuardConfig = {
+  privateKey: string;
+  ipv4Address: string;
+  ipv6Address?: string;
+  mtu?: number;
+  serverPublicKey: string;
+  preSharedKey?: string;
+  endpoint: WireGuardEndpoint;
+  persistentKeepalive?: number;
+  allowedIps: string[];
+  amneziaOptions: Map<string, string>;
+};
+
+type SectionName = 'interface' | 'peer';
+
+const invalidConfiguration = () =>
+  new Error('Invalid WireGuard client configuration');
+
+function getSingleValue(
+  section: Map<string, string>,
+  key: string,
+  required = true
+) {
+  const value = section.get(key.toLowerCase());
+  if (required && !value) {
+    throw invalidConfiguration();
+  }
+  return value;
+}
+
+function parseInteger(
+  value: string | undefined,
+  minimum: number,
+  maximum: number
+) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    throw invalidConfiguration();
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw invalidConfiguration();
+  }
+  return parsed;
+}
+
+function validateWireGuardKey(value: string) {
+  if (!/^[A-Za-z0-9+/]{43}=$/.test(value)) {
+    throw invalidConfiguration();
+  }
+
+  const decoded = Buffer.from(value, 'base64');
+  if (decoded.length !== 32 || decoded.toString('base64') !== value) {
+    throw invalidConfiguration();
+  }
+  return value;
+}
+
+function isValidHost(value: string) {
+  if (isIP(value) !== 0) {
+    return true;
+  }
+
+  if (value.length > 253 || !/^[A-Za-z0-9.-]+$/.test(value)) {
+    return false;
+  }
+
+  const hostname = value.endsWith('.') ? value.slice(0, -1) : value;
+  return hostname
+    .split('.')
+    .every(
+      (label) =>
+        label.length > 0 &&
+        label.length <= 63 &&
+        /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(label)
+    );
+}
+
+function parseAddressList(value: string) {
+  const addresses = value
+    .split(',')
+    .map((address) => address.trim())
+    .filter(Boolean)
+    .map((address) => {
+      if (isCidr(address) === 0) {
+        throw invalidConfiguration();
+      }
+      const slashIndex = address.lastIndexOf('/');
+      const ip = address.slice(0, slashIndex);
+      return { ip, version: isIP(ip) };
+    });
+
+  const ipv4Address = addresses.find(({ version }) => version === 4)?.ip;
+  if (!ipv4Address) {
+    throw invalidConfiguration();
+  }
+
+  return {
+    ipv4Address,
+    ipv6Address: addresses.find(({ version }) => version === 6)?.ip,
+  };
+}
+
+export function parseWireGuardEndpoint(value: string): WireGuardEndpoint {
+  const bracketedIpv6 = value.match(/^\[([^\]]+)]:(\d+)$/);
+  let server: string;
+  let portText: string;
+
+  if (bracketedIpv6) {
+    server = bracketedIpv6[1]!;
+    portText = bracketedIpv6[2]!;
+    if (isIP(server) !== 6) {
+      throw invalidConfiguration();
+    }
+  } else {
+    const separatorIndex = value.lastIndexOf(':');
+    if (separatorIndex <= 0 || value.indexOf(':') !== separatorIndex) {
+      throw invalidConfiguration();
+    }
+    server = value.slice(0, separatorIndex).trim();
+    portText = value.slice(separatorIndex + 1).trim();
+  }
+
+  if (!isValidHost(server)) {
+    throw invalidConfiguration();
+  }
+
+  const port = parseInteger(portText, 1, 65_535);
+  if (port === undefined) {
+    throw invalidConfiguration();
+  }
+
+  return { server, port };
+}
+
+export function parseWireGuardClientConfig(
+  config: string
+): ParsedWireGuardConfig {
+  const sections: Record<SectionName, Map<string, string>> = {
+    interface: new Map(),
+    peer: new Map(),
+  };
+  const sectionCounts: Record<SectionName, number> = {
+    interface: 0,
+    peer: 0,
+  };
+  let currentSection: SectionName | null = null;
+
+  for (const rawLine of config.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#') || line.startsWith(';')) {
+      continue;
+    }
+
+    const header = line.match(/^\[([^\]]+)]$/);
+    if (header) {
+      const name = header[1]!.toLowerCase();
+      currentSection = name === 'interface' || name === 'peer' ? name : null;
+      if (currentSection) {
+        sectionCounts[currentSection] += 1;
+      }
+      continue;
+    }
+
+    if (!currentSection) {
+      throw invalidConfiguration();
+    }
+
+    const separatorIndex = line.indexOf('=');
+    if (separatorIndex <= 0) {
+      throw invalidConfiguration();
+    }
+
+    const key = line.slice(0, separatorIndex).trim().toLowerCase();
+    const value = line.slice(separatorIndex + 1).trim();
+    if (!key || !value || sections[currentSection].has(key)) {
+      throw invalidConfiguration();
+    }
+    sections[currentSection].set(key, value);
+  }
+
+  if (sectionCounts.interface !== 1 || sectionCounts.peer !== 1) {
+    throw invalidConfiguration();
+  }
+
+  const interfaceSection = sections.interface;
+  const peerSection = sections.peer;
+  const privateKey = validateWireGuardKey(
+    getSingleValue(interfaceSection, 'PrivateKey')!
+  );
+  const address = getSingleValue(interfaceSection, 'Address')!;
+  const serverPublicKey = validateWireGuardKey(
+    getSingleValue(peerSection, 'PublicKey')!
+  );
+  const endpoint = parseWireGuardEndpoint(
+    getSingleValue(peerSection, 'Endpoint')!
+  );
+  const allowedIps = getSingleValue(peerSection, 'AllowedIPs')!
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (
+    !allowedIps.includes('0.0.0.0/0') ||
+    allowedIps.some((entry) => isCidr(entry) === 0)
+  ) {
+    throw invalidConfiguration();
+  }
+
+  const preSharedKeyValue = getSingleValue(peerSection, 'PresharedKey', false);
+
+  const amneziaOptions = new Map<string, string>();
+  for (const key of [
+    'Jc',
+    'Jmin',
+    'Jmax',
+    'S1',
+    'S2',
+    'S3',
+    'S4',
+    'H1',
+    'H2',
+    'H3',
+    'H4',
+    'I1',
+    'I2',
+    'I3',
+    'I4',
+    'I5',
+  ]) {
+    const value = getSingleValue(interfaceSection, key, false);
+    if (value) {
+      amneziaOptions.set(key.toLowerCase(), value);
+    }
+  }
+
+  return {
+    privateKey,
+    ...parseAddressList(address),
+    mtu: parseInteger(
+      getSingleValue(interfaceSection, 'MTU', false),
+      576,
+      9_000
+    ),
+    serverPublicKey,
+    preSharedKey: preSharedKeyValue
+      ? validateWireGuardKey(preSharedKeyValue)
+      : undefined,
+    endpoint,
+    persistentKeepalive: parseInteger(
+      getSingleValue(peerSection, 'PersistentKeepalive', false),
+      0,
+      65_535
+    ),
+    allowedIps,
+    amneziaOptions,
+  };
+}
+
+export function parseFlClashRemoteCidrs(value: string) {
+  const cidrs = [
+    ...new Set(
+      value
+        .split(/[\s,]+/)
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    ),
+  ];
+
+  if (cidrs.length === 0 || cidrs.length > 32) {
+    throw new Error('Invalid FlClash remote CIDR configuration');
+  }
+
+  for (const cidr of cidrs) {
+    if (isCidr(cidr) === 0) {
+      throw new Error('Invalid FlClash remote CIDR configuration');
+    }
+  }
+  return cidrs;
+}
+
+export function parseFlClashEndpointIpVersion(
+  value: string
+): FlClashEndpointIpVersion {
+  if (!ENDPOINT_IP_VERSIONS.includes(value as FlClashEndpointIpVersion)) {
+    throw new Error('Invalid FlClash endpoint IP version');
+  }
+  return value as FlClashEndpointIpVersion;
+}
+
+function renderAmneziaOptions(options: Map<string, string>) {
+  if (options.size === 0) {
+    return '';
+  }
+
+  const numericKeys = new Set(['jc', 'jmin', 'jmax', 's1', 's2', 's3', 's4']);
+  const headerKeys = new Set(['h1', 'h2', 'h3', 'h4']);
+  const lines = ['    amnezia-wg-option:'];
+
+  for (const [key, value] of options) {
+    if (numericKeys.has(key)) {
+      if (!/^\d+$/.test(value)) {
+        throw invalidConfiguration();
+      }
+      lines.push(`      ${key}: ${value}`);
+    } else if (headerKeys.has(key)) {
+      if (!/^\d+(?:-\d+)?$/.test(value)) {
+        throw invalidConfiguration();
+      }
+      lines.push(`      ${key}: ${value}`);
+    } else {
+      lines.push(`      ${key}: ${JSON.stringify(value)}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function generateFlClashConfig(
+  wireGuardConfig: string,
+  options: FlClashOptions
+) {
+  const parsed = parseWireGuardClientConfig(wireGuardConfig);
+  const remoteCidrs = parseFlClashRemoteCidrs(options.remoteCidrs.join(','));
+  const hasIpv6Tunnel =
+    parsed.ipv6Address !== undefined && parsed.allowedIps.includes('::/0');
+
+  if (!hasIpv6Tunnel && remoteCidrs.some((cidr) => isCidr(cidr) === 6)) {
+    throw new Error('IPv6 remote CIDR requires an IPv6 WireGuard tunnel');
+  }
+
+  const quote = (value: string) => JSON.stringify(value);
+  const endpointIsDomain = isIP(parsed.endpoint.server) === 0;
+  const applicationDnsParameter = hasIpv6Tunnel ? '' : '#disable-ipv6=true';
+  const proxiedDnsParameter = hasIpv6Tunnel
+    ? '#WG-ROUTER'
+    : '#WG-ROUTER&disable-ipv6=true';
+
+  const endpointPolicy = endpointIsDomain
+    ? `  proxy-server-nameserver-policy:\n    ${quote(parsed.endpoint.server)}:\n${
+        options.endpointIpVersion === 'ipv6'
+          ? '      - "223.5.5.5#disable-ipv4=true"\n      - "119.29.29.29#disable-ipv4=true"\n'
+          : options.endpointIpVersion === 'ipv4'
+            ? '      - "223.5.5.5#disable-ipv6=true"\n      - "119.29.29.29#disable-ipv6=true"\n'
+            : '      - 223.5.5.5\n      - 119.29.29.29\n'
+      }`
+    : '';
+
+  const ipv6ProxyLine = hasIpv6Tunnel
+    ? `    ipv6: ${quote(parsed.ipv6Address!)}\n`
+    : '';
+  const preSharedKeyLine = parsed.preSharedKey
+    ? `    pre-shared-key: ${quote(parsed.preSharedKey)}\n`
+    : '';
+  const mtuLine = parsed.mtu ? `    mtu: ${parsed.mtu}\n` : '';
+  const keepaliveLine =
+    parsed.persistentKeepalive !== undefined
+      ? `    persistent-keepalive: ${parsed.persistentKeepalive}\n`
+      : '';
+  const ipv6AllowedIpLine = hasIpv6Tunnel ? '      - ::/0\n' : '';
+  const remoteRules = remoteCidrs
+    .map(
+      (cidr) =>
+        `  - ${isCidr(cidr) === 6 ? 'IP-CIDR6' : 'IP-CIDR'},${cidr},WG-ROUTER,no-resolve`
+    )
+    .join('\n');
+  const ipv6FallbackRule = hasIpv6Tunnel
+    ? ''
+    : '  # 当前 WireGuard 隧道只有 IPv4；阻止 IPv6 旁路泄漏。\n  - IP-CIDR6,::/0,REJECT,no-resolve\n\n';
+
+  return `# FlClash / Mihomo 分流配置
+# 包含 WireGuard 客户端私钥，请勿上传、分享或截图。
+mixed-port: 7890
+allow-lan: false
+mode: rule
+log-level: info
+ipv6: true
+unified-delay: true
+tcp-concurrent: true
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+tun:
+  enable: true
+  stack: mixed
+  auto-route: true
+  auto-detect-interface: true
+  strict-route: true
+  dns-hijack:
+    - any:53
+    - tcp://any:53
+
+# 这是 Mihomo 的分流解析设置，不会写入 WireGuard 的 DNS 字段。
+dns:
+  enable: true
+  listen: 0.0.0.0:1053
+  # 保持 DNS 内核可解析 IPv6 公网端点；无 IPv6 隧道时由下方 DNS 参数过滤业务 AAAA。
+  ipv6: true
+  enhanced-mode: fake-ip
+  fake-ip-range: 198.18.0.1/16
+  respect-rules: false
+  default-nameserver:
+    - 223.5.5.5
+    - 119.29.29.29
+  nameserver:
+    - ${quote(`https://1.1.1.1/dns-query${proxiedDnsParameter}`)}
+    - ${quote(`https://8.8.8.8/dns-query${proxiedDnsParameter}`)}
+  nameserver-policy:
+    "geosite:cn":
+      - ${quote(`https://dns.alidns.com/dns-query${applicationDnsParameter}`)}
+      - ${quote(`https://doh.pub/dns-query${applicationDnsParameter}`)}
+  proxy-server-nameserver:
+    - 223.5.5.5
+    - 119.29.29.29
+${endpointPolicy}  direct-nameserver:
+    - ${quote(`223.5.5.5${applicationDnsParameter}`)}
+    - ${quote(`119.29.29.29${applicationDnsParameter}`)}
+  fake-ip-filter:
+    - "*.lan"
+    - "*.local"
+
+proxies:
+  - name: WG-ROUTER
+    type: wireguard
+    server: ${quote(parsed.endpoint.server)}
+    port: ${parsed.endpoint.port}
+    ip-version: ${options.endpointIpVersion}
+    ip: ${quote(parsed.ipv4Address)}
+${ipv6ProxyLine}    private-key: ${quote(parsed.privateKey)}
+    public-key: ${quote(parsed.serverPublicKey)}
+${preSharedKeyLine}    allowed-ips:
+      - 0.0.0.0/0
+${ipv6AllowedIpLine}    udp: true
+${mtuLine}${keepaliveLine}${renderAmneziaOptions(parsed.amneziaOptions)}
+proxy-groups:
+  - name: 境外和远程局域网
+    type: select
+    proxies:
+      - WG-ROUTER
+
+rules:
+  # 远端局域网和 WireGuard 隧道网段必须优先进入 WireGuard。
+${remoteRules}
+
+${ipv6FallbackRule}  # 国内域名与国内 IP 使用手机当前网络。
+  - GEOSITE,cn,DIRECT
+  - GEOIP,CN,DIRECT
+
+  # 其他流量先进入 WireGuard，再由远端路由器处理境外代理。
+  - MATCH,境外和远程局域网
+`;
+}

--- a/src/test/unit/flClash.spec.ts
+++ b/src/test/unit/flClash.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  generateFlClashConfig,
+  parseFlClashEndpointIpVersion,
+  parseFlClashRemoteCidrs,
+  parseWireGuardClientConfig,
+  parseWireGuardEndpoint,
+} from '../../server/utils/flClash';
+
+const PRIVATE_KEY = 'AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=';
+const PUBLIC_KEY = 'AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=';
+const PRE_SHARED_KEY = 'AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=';
+
+const standardConfig = `[Interface]
+PrivateKey = ${PRIVATE_KEY}
+Address = 10.0.8.3/32
+MTU = 1280
+DNS = 192.0.2.1
+
+[Peer]
+PublicKey = ${PUBLIC_KEY}
+PresharedKey = ${PRE_SHARED_KEY}
+AllowedIPs = 0.0.0.0/0
+PersistentKeepalive = 25
+Endpoint = wrt.example.com:51820`;
+
+describe('FlClash profile generator', () => {
+  test('parses standard WireGuard fields without breaking Base64 padding', () => {
+    expect(parseWireGuardClientConfig(standardConfig)).toMatchObject({
+      privateKey: PRIVATE_KEY,
+      ipv4Address: '10.0.8.3',
+      mtu: 1280,
+      serverPublicKey: PUBLIC_KEY,
+      preSharedKey: PRE_SHARED_KEY,
+      endpoint: { server: 'wrt.example.com', port: 51820 },
+      persistentKeepalive: 25,
+      allowedIps: ['0.0.0.0/0'],
+    });
+  });
+
+  test('parses bracketed IPv6 endpoints', () => {
+    expect(parseWireGuardEndpoint('[2001:db8::1]:51820')).toEqual({
+      server: '2001:db8::1',
+      port: 51820,
+    });
+  });
+
+  test('generates IPv4 data-plane profile for an IPv6-only endpoint', () => {
+    const result = generateFlClashConfig(standardConfig, {
+      remoteCidrs: ['10.0.8.0/24', '192.168.1.0/24'],
+      endpointIpVersion: 'ipv6',
+    });
+
+    expect(result).toContain('type: wireguard');
+    expect(result).toContain('server: "wrt.example.com"');
+    expect(result).toContain('port: 51820');
+    expect(result).toContain('ip-version: ipv6');
+    expect(result).toContain('ip: "10.0.8.3"');
+    expect(result).toContain(`private-key: "${PRIVATE_KEY}"`);
+    expect(result).toContain(`public-key: "${PUBLIC_KEY}"`);
+    expect(result).toContain(`pre-shared-key: "${PRE_SHARED_KEY}"`);
+    expect(result).toContain('      - 0.0.0.0/0');
+    expect(result).not.toContain('      - ::/0');
+    expect(result).toContain('  ipv6: true');
+    expect(result).toContain(
+      '"wrt.example.com":\n      - "223.5.5.5#disable-ipv4=true"'
+    );
+    expect(result).toContain(
+      '"https://1.1.1.1/dns-query#WG-ROUTER&disable-ipv6=true"'
+    );
+    expect(result).toContain(
+      '"https://dns.alidns.com/dns-query#disable-ipv6=true"'
+    );
+    expect(result).toContain('"223.5.5.5#disable-ipv6=true"');
+
+    const lanRule = result.indexOf(
+      'IP-CIDR,192.168.1.0/24,WG-ROUTER,no-resolve'
+    );
+    const tunnelRule = result.indexOf(
+      'IP-CIDR,10.0.8.0/24,WG-ROUTER,no-resolve'
+    );
+    const ipv6RejectRule = result.indexOf('IP-CIDR6,::/0,REJECT,no-resolve');
+    const geositeRule = result.indexOf('GEOSITE,cn,DIRECT');
+    const geoipRule = result.indexOf('GEOIP,CN,DIRECT');
+    const matchRule = result.indexOf('MATCH,境外和远程局域网');
+    expect(lanRule).toBeGreaterThan(-1);
+    expect(tunnelRule).toBeGreaterThan(-1);
+    expect(lanRule).toBeLessThan(geositeRule);
+    expect(tunnelRule).toBeLessThan(geositeRule);
+    expect(ipv6RejectRule).toBeLessThan(geositeRule);
+    expect(geositeRule).toBeLessThan(geoipRule);
+    expect(geoipRule).toBeLessThan(matchRule);
+    expect(result).not.toContain('DNS =');
+    expect(result).toContain('  - name: 境外和远程局域网');
+    expect(result).toContain('  - MATCH,境外和远程局域网');
+  });
+
+  test('enables the IPv6 data-plane only when Address and AllowedIPs allow it', () => {
+    const dualStack = standardConfig
+      .replace('Address = 10.0.8.3/32', 'Address = 10.0.8.3/32, fd00::3/128')
+      .replace('AllowedIPs = 0.0.0.0/0', 'AllowedIPs = 0.0.0.0/0, ::/0');
+    const result = generateFlClashConfig(dualStack, {
+      remoteCidrs: ['192.168.1.0/24'],
+      endpointIpVersion: 'dual',
+    });
+
+    expect(result).toContain('    ipv6: "fd00::3"');
+    expect(result).toContain('      - ::/0');
+    expect(result).toContain('  ipv6: true');
+    expect(result).not.toContain('IP-CIDR6,::/0,REJECT');
+    expect(result).not.toContain('disable-ipv6=true');
+  });
+
+  test('maps AmneziaWG fields without treating them as standard WireGuard', () => {
+    const amnezia = standardConfig.replace(
+      'MTU = 1280',
+      'MTU = 1280\nJc = 7\nJmin = 10\nJmax = 1000\nS1 = 128\nS2 = 56\nH1 = 123456\nI1 = <b 0xf6ab>'
+    );
+    const result = generateFlClashConfig(amnezia, {
+      remoteCidrs: ['192.168.1.0/24'],
+      endpointIpVersion: 'dual',
+    });
+
+    expect(result).toContain('    amnezia-wg-option:');
+    expect(result).toContain('      jc: 7');
+    expect(result).toContain('      h1: 123456');
+    expect(result).toContain('      i1: "<b 0xf6ab>"');
+  });
+
+  test('rejects malformed configs and unsafe environment values', () => {
+    expect(() =>
+      parseWireGuardClientConfig(
+        standardConfig.replace(
+          'AllowedIPs = 0.0.0.0/0',
+          'AllowedIPs = 10.0.0.0/8'
+        )
+      )
+    ).toThrow('Invalid WireGuard client configuration');
+    expect(() =>
+      parseWireGuardClientConfig(
+        standardConfig.replace(
+          `PrivateKey = ${PRIVATE_KEY}`,
+          `PrivateKey = ${PRIVATE_KEY}\nPrivateKey = ${PUBLIC_KEY}`
+        )
+      )
+    ).toThrow('Invalid WireGuard client configuration');
+    expect(() => parseFlClashRemoteCidrs('not-a-cidr')).toThrow();
+    expect(() => parseFlClashEndpointIpVersion('automatic')).toThrow();
+    expect(() => parseWireGuardEndpoint('bad host.example:51820')).toThrow();
+    expect(() =>
+      generateFlClashConfig(standardConfig, {
+        remoteCidrs: ['fd00::/64'],
+        endpointIpVersion: 'ipv6',
+      })
+    ).toThrow('IPv6 remote CIDR requires an IPv6 WireGuard tunnel');
+  });
+});


### PR DESCRIPTION
## Description

Adds an optional **FC** action next to the regular WireGuard configuration download. The new endpoint converts the selected client's existing WireGuard configuration into a FlClash/Mihomo profile without storing or logging the generated profile.

The generated profile:

- routes the WireGuard tunnel CIDRs and optional remote LAN CIDRs through WireGuard;
- routes Chinese domains and IP ranges directly;
- routes remaining traffic through the remote WireGuard peer;
- supports IPv4, IPv6, dual-stack endpoints, and AmneziaWG options;
- returns private/no-store response headers because the profile contains the client private key.

Two optional environment variables are documented:

- `FLCLASH_REMOTE_CIDRS`
- `FLCLASH_ENDPOINT_IP_VERSION`

## Motivation and Context

This supports users who need selective routing on mobile or desktop clients: local Chinese traffic can continue using the current network while remote LAN and non-Chinese traffic are sent through a wg-easy peer and processed by the remote router.

## How has this been tested?

- `pnpm test:unit`: 48 tests passed
- `pnpm typecheck`: passed
- `pnpm lint`: passed
- `pnpm build`: passed
- Prettier and `git diff --check` passed for all changed files
- Added unit coverage for standard WireGuard parsing, bracketed IPv6 endpoints, IPv4/IPv6 profiles, AmneziaWG fields, invalid keys, CIDRs, endpoint modes, and route ordering

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (change which does not alter existing functionality)
- [x] Documentation (changes to documentation only)

## Checklist

- [x] I have reviewed my own changes.
- [x] My code follows the code style of this project.
- [x] I have added or updated tests where appropriate.
- [x] My changes do not include unrelated modifications.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## AI Disclosure

OpenAI Codex was used to help port an existing locally tested implementation from wg-easy v15.3.0 to the current `master`, adapt it to current project conventions, draft tests and documentation, and run the validation commands listed above. The contributor remains responsible for reviewing, understanding, testing, and maintaining the submitted changes.