### PR TITLE
i18n(es): Update and complete Spanish translation

### DIFF
--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -20,7 +20,11 @@
     "2faKey": "Clave TOTP",
     "2faCodeDesc": "Introduce el código de tu aplicación de autenticación.",
     "disable2fa": "Desactivar autenticación en dos pasos",
-    "disable2faDesc": "Introduce tu contraseña para desactivar la autenticación en dos pasos."
+    "disable2faDesc": "Introduce tu contraseña para desactivar la autenticación en dos pasos.",
+    "linkOauth": "Vincula tu cuenta con un proveedor externo",
+    "unlinkOauth": "Desvincular",
+    "linkedWith": "Vinculado con {provider}",
+    "providerDisabled": "El proveedor vinculado a tu cuenta no está activado"
   },
   "general": {
     "name": "Nombre",
@@ -28,6 +32,7 @@
     "password": "Contraseña",
     "newPassword": "Nueva contraseña",
     "updatePassword": "Actualizar contraseña",
+    "addPassword": "Añadir contraseña",
     "mtu": "MTU",
     "allowedIps": "IPs permitidas",
     "dns": "DNS",
@@ -41,7 +46,8 @@
     "confirmPassword": "Confirmar contraseña",
     "loading": "Cargando...",
     "2fa": "Autenticación en dos pasos",
-    "2faCode": "Código TOTP"
+    "2faCode": "Código TOTP",
+    "externalAuth": "Autenticación externa"
   },
   "setup": {
     "welcome": "Bienvenido a tu primera configuración de wg-easy",
@@ -72,11 +78,14 @@
   },
   "login": {
     "signIn": "Iniciar sesión",
+    "signInWith": "Iniciar sesión con {provider}",
+    "or": "o",
     "rememberMe": "Recordarme",
     "rememberMeDesc": "Mantener sesión iniciada tras cerrar el navegador",
     "insecure": "No puedes iniciar sesión con una conexión no segura. Usa HTTPS.",
     "2faRequired": "Se requiere autenticación en dos pasos",
-    "2faWrong": "El código de autenticación en dos pasos es incorrecto"
+    "2faWrong": "El código de autenticación en dos pasos es incorrecto",
+    "loginExpired": "Inicio de sesión caducado. Vuelve a intentarlo"
   },
   "client": {
     "empty": "No hay clientes todavía.",
@@ -88,6 +97,7 @@
     "name": "Nombre",
     "expireDate": "Fecha de expiración",
     "expireDateDesc": "Fecha en que el cliente será desactivado. En blanco = permanente",
+    "delete": "Eliminar",
     "deleteClient": "Eliminar cliente",
     "deleteDialog": "¿Estás seguro de que deseas eliminar a {name}? Esta acción no se puede deshacer.",
     "enabled": "Habilitado",
@@ -115,7 +125,7 @@
     "dnsDesc": "Servidor DNS que usarán los clientes (anula la configuración global)",
     "notConnected": "Cliente no conectado",
     "endpoint": "Punto de conexión",
-    "endpointDesc": "IP del cliente desde donde se establece la conexión WireGuard",
+    "endpointDesc": "IP del cliente desde la que se establece la conexión WireGuard",
     "search": "Buscar clientes...",
     "config": "Configuración",
     "viewConfig": "Ver configuración",
@@ -172,6 +182,8 @@
       "cidrSuccess": "CIDR cambiado",
       "device": "Dispositivo",
       "deviceDesc": "Dispositivo Ethernet por donde se reenviará el tráfico de WireGuard",
+      "routingTable": "Tabla de enrutamiento",
+      "routingTableDesc": "Tabla de enrutamiento para las rutas de WireGuard. Puede ser auto, off o un número de tabla.",
       "mtuDesc": "MTU que usará WireGuard",
       "portDesc": "Puerto UDP en el que escuchará WireGuard (debes cambiar también el puerto de config)",
       "changeCidr": "Cambiar CIDR",
@@ -194,7 +206,9 @@
       "validBoolean": "{field} debe ser un booleano válido",
       "validArray": "{field} debe ser una lista válida",
       "stringMin": "{field} debe tener al menos {min} caracteres",
-      "numberMin": "{field} debe ser al menos {min}"
+      "stringMax": "{field} debe tener como máximo {max} caracteres",
+      "numberMin": "{field} debe ser al menos {min}",
+      "numberMax": "{field} debe ser como máximo {max}"
     },
     "client": {
       "id": "ID del cliente",
@@ -229,7 +243,8 @@
     "interface": {
       "cidr": "CIDR",
       "device": "Dispositivo",
-      "cidrValid": "El CIDR debe ser válido"
+      "cidrValid": "El CIDR debe ser válido",
+      "routingTable": "La tabla de enrutamiento debe de ser auto, off, o un número de tabla"
     },
     "otl": "Enlace de un solo uso",
     "stringMalformed": "Cadena malformada",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -244,7 +244,7 @@
       "cidr": "CIDR",
       "device": "Dispositivo",
       "cidrValid": "El CIDR debe ser válido",
-      "routingTable": "La tabla de enrutamiento debe de ser auto, off, o un número de tabla"
+      "routingTable": "La tabla de enrutamiento debe ser auto, off o un número de tabla"
     },
     "otl": "Enlace de un solo uso",
     "stringMalformed": "Cadena malformada",


### PR DESCRIPTION
## Description

Revises the Spanish locale (`src/i18n/locales/es.json`) for completeness and accuracy. 252 keys total, matching `en.json` with no missing or extra keys.

**Newly translated (were missing entirely / falling back to English):**
`me.linkOauth`, `me.unlinkOauth`, `me.linkedWith`, `me.providerDisabled`, `general.addPassword`, `general.externalAuth`, `login.signInWith`, `login.or`, `login.loginExpired`, `client.delete`, `admin.interface.routingTable`, `admin.interface.routingTableDesc`, `zod.generic.stringMax`, `zod.generic.numberMax`, `zod.interface.routingTable`.

**Grammar fixes:**
- `client.endpointDesc`: changed "desde donde" to "desde la que", agreeing with "IP" (feminine) rather than using a generic locative.

No key was added or removed relative to `en.json`, and no source file outside the Spanish locale is touched.

## Motivation and Context

Several strings added in recent updates (OAuth linking, routing table, extended validation messages) had never been translated and were falling back to English for Spanish users.

## How has this been tested?

- Verified `es.json` is valid JSON.
- Ran `bash scripts/i18n.sh`, `es` reports 100% key coverage.
- Diffed against `en.json` to confirm key parity (252/252 keys, no missing or extra).
- Manually reviewed every changed string for grammar and naturalness as a Spanish speaker.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (change which does not alter existing functionality)
- [ ] Documentation (changes to documentation only)

## Checklist

- [x] I have reviewed my own changes.
- [x] My code follows the code style of this project.
- [ ] I have added or updated tests where appropriate.
- [x] My changes do not include unrelated modifications.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## AI Disclosure

AI-assisted. I used Claude (Claude Code) as a discussion partner to review each translated string for grammar, naturalness, and terminology consistency in Spanish.

I am a Spanish speaker and made every final wording decision myself. I can explain and defend every change in this PR.
