### PR TITLE
fix: allow return traffic from client-routed subnets in per-client firewall

### DIFF
--- a/src/server/utils/firewall.ts
+++ b/src/server/utils/firewall.ts
@@ -30,8 +30,26 @@ type FirewallClient = Pick<
   | 'ipv6Address'
   | 'allowedIps'
   | 'firewallIps'
+  | 'serverAllowedIps'
   | 'enabled'
 >;
+
+/**
+ * Additional subnets a client routes beyond its own tunnel address(es) --
+ * i.e. Server Allowed IPs entries that aren't just the client's own /32 or
+ * /128 identity. A client with such entries is acting as a site-to-site
+ * gateway, routing a LAN or other network (e.g. Kubernetes Pod/Service
+ * CIDRs) behind it.
+ */
+function getRoutedSubnets(client: FirewallClient): string[] {
+  const ownAddresses = new Set([
+    `${client.ipv4Address}/32`,
+    `${client.ipv6Address}/128`,
+  ]);
+  return (client.serverAllowedIps ?? []).filter(
+    (entry) => !ownAddresses.has(entry)
+  );
+}
 
 /**
  * Sanitize a client identifier for use in an iptables comment.
@@ -204,7 +222,9 @@ export const firewall = {
   async applyClientRules(
     client: FirewallClient,
     defaultAllowedIps: string[],
-    enableIpv6: boolean
+    enableIpv6: boolean,
+    ipv4Cidr: string,
+    ipv6Cidr: string
   ): Promise<void> {
     // Determine which IPs to use for firewall rules
     // Priority: firewallIps > allowedIps > defaultAllowedIps
@@ -233,6 +253,36 @@ export const firewall = {
         }
       } else {
         const rules = generateRuleArgs(client.ipv4Address, parsed, comment);
+        for (const rule of rules) {
+          await exec(`iptables ${rule}`);
+        }
+      }
+    }
+
+    // A client acting as a site-to-site gateway routes additional subnets
+    // behind it (Server Allowed IPs beyond its own tunnel address). Return
+    // traffic from those subnets has that subnet as its source, not the
+    // gateway's own tunnel IP -- without an explicit rule for it, the
+    // above per-client rules never match it and it falls through to the
+    // chain's final DROP, even though the original outbound request (and
+    // the requesting client's own rules) allowed it.
+    //
+    // These rules only permit that return traffic to reach the VPN's own
+    // address pool: access control for who may reach the routed subnet in
+    // the first place is still enforced by the requesting client's own
+    // rules above, unaffected by this.
+    for (const subnet of getRoutedSubnets(client)) {
+      const subnetIsIpv6 = isIPv6(subnet.split('/')[0] ?? subnet);
+
+      if (subnetIsIpv6) {
+        if (enableIpv6 && ipv6Cidr) {
+          const rules = generateRuleArgs(subnet, { ip: ipv6Cidr }, comment);
+          for (const rule of rules) {
+            await exec(`ip6tables ${rule}`);
+          }
+        }
+      } else if (ipv4Cidr) {
+        const rules = generateRuleArgs(subnet, { ip: ipv4Cidr }, comment);
         for (const rule of rules) {
           await exec(`iptables ${rule}`);
         }
@@ -279,7 +329,9 @@ export const firewall = {
         await this.applyClientRules(
           client,
           userConfig.defaultAllowedIps,
-          enableIpv6
+          enableIpv6,
+          wgInterface.ipv4Cidr,
+          wgInterface.ipv6Cidr
         );
       }
 
@@ -374,4 +426,5 @@ export const firewallTestExports = {
   parseFirewallEntry,
   generateRuleArgs,
   sanitizeComment,
+  getRoutedSubnets,
 };

--- a/src/test/unit/firewall.spec.ts
+++ b/src/test/unit/firewall.spec.ts
@@ -287,6 +287,146 @@ describe('firewall', () => {
       expect(result).toBe('client 1: ' + 'a'.repeat(246));
     });
   });
+  describe('getRoutedSubnets', () => {
+    test('excludes the client own tunnel addresses', () => {
+      expect(
+        firewallTestExports.getRoutedSubnets({
+          id: 1,
+          name: 'gateway',
+          ipv4Address: '10.8.0.3',
+          ipv6Address: 'fd00::3',
+          allowedIps: null,
+          firewallIps: null,
+          serverAllowedIps: ['10.8.0.3/32', 'fd00::3/128'],
+          enabled: true,
+        })
+      ).toEqual([]);
+    });
+
+    test('returns additional routed subnets beyond the own tunnel addresses', () => {
+      expect(
+        firewallTestExports.getRoutedSubnets({
+          id: 1,
+          name: 'gateway',
+          ipv4Address: '10.8.0.3',
+          ipv6Address: 'fd00::3',
+          allowedIps: null,
+          firewallIps: null,
+          serverAllowedIps: [
+            '10.8.0.3/32',
+            'fd00::3/128',
+            '192.168.1.0/24',
+            'fd10::/64',
+          ],
+          enabled: true,
+        })
+      ).toEqual(['192.168.1.0/24', 'fd10::/64']);
+    });
+
+    test('returns an empty array when serverAllowedIps is empty or null', () => {
+      expect(
+        firewallTestExports.getRoutedSubnets({
+          id: 1,
+          name: 'regular-client',
+          ipv4Address: '10.8.0.2',
+          ipv6Address: 'fd00::2',
+          allowedIps: null,
+          firewallIps: null,
+          serverAllowedIps: [],
+          enabled: true,
+        })
+      ).toEqual([]);
+    });
+  });
+
+  describe('applyClientRules: routed subnets (site-to-site gateways)', () => {
+    test('adds a return-traffic rule for an additional routed subnet', async () => {
+      await firewall.applyClientRules(
+        {
+          id: 58,
+          name: 'gateway',
+          ipv4Address: '10.8.0.51',
+          ipv6Address: 'fd00::51',
+          allowedIps: ['10.8.0.0/24'],
+          firewallIps: null,
+          serverAllowedIps: ['10.8.0.51/32', '172.17.0.0/16'],
+          enabled: true,
+        },
+        ['10.0.0.0/8'],
+        false,
+        '10.8.0.0/24',
+        'fd00::/64'
+      );
+
+      expect(execMock).toHaveBeenCalledWith(
+        expect.stringContaining('-A WG_CLIENTS -s 172.17.0.0/16 -d 10.8.0.0/24')
+      );
+    });
+
+    test('adds an IPv6 return-traffic rule only when IPv6 is enabled', async () => {
+      const client = {
+        id: 58,
+        name: 'gateway',
+        ipv4Address: '10.8.0.51',
+        ipv6Address: 'fd00::51',
+        allowedIps: ['10.8.0.0/24'],
+        firewallIps: null,
+        serverAllowedIps: ['10.8.0.51/32', 'fd10::/64'],
+        enabled: true,
+      };
+
+      await firewall.applyClientRules(
+        client,
+        ['10.0.0.0/8'],
+        false,
+        '10.8.0.0/24',
+        'fd00::/64'
+      );
+      expect(execMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('ip6tables')
+      );
+
+      execMock.mockClear();
+
+      await firewall.applyClientRules(
+        client,
+        ['10.0.0.0/8'],
+        true,
+        '10.8.0.0/24',
+        'fd00::/64'
+      );
+      expect(execMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'ip6tables -A WG_CLIENTS -s fd10::/64 -d fd00::/64'
+        )
+      );
+    });
+
+    test('does not add any return-traffic rule for a regular client', async () => {
+      await firewall.applyClientRules(
+        {
+          id: 3,
+          name: 'laptop',
+          ipv4Address: '10.8.0.2',
+          ipv6Address: 'fd00::2',
+          allowedIps: ['0.0.0.0/0'],
+          firewallIps: null,
+          serverAllowedIps: [],
+          enabled: true,
+        },
+        ['10.0.0.0/8'],
+        false,
+        '10.8.0.0/24',
+        'fd00::/64'
+      );
+
+      const calls = execMock.mock.calls.map((call) => call[0]);
+      expect(calls.some((cmd) => String(cmd).includes('-d 10.8.0.0/24'))).toBe(
+        false
+      );
+    });
+  });
+
   describe('generateRuleArgs', () => {
     test('includes comment when provided', () => {
       const rules = firewallTestExports.generateRuleArgs(


### PR DESCRIPTION
## Description

The `WG_CLIENTS` chain only ever matches a client's own tunnel IP as a source. When a client acts as a site-to-site gateway (its "Server Allowed IPs" include a subnet beyond its own `/32`/`/128`), return traffic from that subnet has the subnet's own address as source, not the gateway's tunnel IP — so it never matches that client's rule and falls through to the final catch-all `DROP`, even though the original outbound request was allowed.

This adds an `ACCEPT` rule per additional routed subnet (`serverAllowedIps` entries beyond the client's own tunnel address), permitting that return traffic back into the VPN's own address pool (`Interface.ipv4Cidr`/`ipv6Cidr`). Access control for who may reach the routed subnet in the first place is unaffected — that's still enforced by the requesting client's own rules, which this change doesn't touch.

Clients without additional routed subnets (the vast majority) generate zero extra rules, so there's no behavior change for the normal case.

## Motivation and Context

Fixes #2769. See that issue and [the comment there](https://github.com/wg-easy/wg-easy/issues/2769#issuecomment-5514733982) for a detailed root-cause writeup, confirmation the fix pattern works when applied manually, and a description of a temporary workaround.

## How has this been tested?

- Added unit tests covering `getRoutedSubnets` (excludes the client's own tunnel addresses, returns additional routed subnets, empty when none) and `applyClientRules` (adds the new return-traffic rule for a gateway client, respects `enableIpv6`, adds nothing extra for a regular client).
- `pnpm test:unit`: 49 passed (43 existing + 6 new).
- `pnpm check:all` (typecheck, lint, format, build): passes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (change which does not alter existing functionality)
- [ ] Documentation (changes to documentation only)

## Checklist

- [x] I have reviewed my own changes.
- [x] My code follows the code style of this project.
- [x] I have added or updated tests where appropriate.
- [x] My changes do not include unrelated modifications.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## AI Disclosure

Claude Code was used to help investigate the root cause (traced through the built server bundle before locating the actual source) and draft this fix and its tests. I reviewed the change, ran the full test/lint/typecheck/build suite locally, and can speak to the implementation.