### PR TITLE
fix: sync routes after WireGuard config changes

### DIFF
--- a/src/server/utils/WireGuard.ts
+++ b/src/server/utils/WireGuard.ts
@@ -85,7 +85,7 @@ class WireGuard {
 
   async #syncWireguardConfig(wgInterface: InterfaceType) {
     WG_DEBUG('Syncing Config...');
-    await wg.sync(wgInterface.name);
+    await wg.sync(wgInterface.name, wgInterface.routingTable);
     WG_DEBUG('Config synced successfully.');
   }
 

--- a/src/server/utils/wgHelper.ts
+++ b/src/server/utils/wgHelper.ts
@@ -1,5 +1,6 @@
 import { parseCidr } from 'cidr-tools';
 import { stringifyIp } from 'ip-bigint';
+import isCidr from 'is-cidr';
 
 import { removeNewlines, iptablesTemplate } from '#server/utils/template';
 import { exec } from '#server/utils/cmd';
@@ -16,6 +17,95 @@ type Options = {
 // needed to support cli
 const wgExecutable =
   typeof WG_ENV !== 'undefined' ? WG_ENV.WG_EXECUTABLE : 'dev';
+
+function parseRunningAllowedIps(output: string) {
+  const allowedIps = new Set<string>();
+
+  for (const line of output.split('\n')) {
+    const separator = line.indexOf('\t');
+    if (separator === -1) {
+      continue;
+    }
+
+    for (const value of line.slice(separator + 1).split(/\s+/)) {
+      if (isCidr(value)) {
+        allowedIps.add(value);
+      }
+    }
+  }
+
+  return allowedIps;
+}
+
+function parseConfigAllowedIps(output: string) {
+  const allowedIps = new Set<string>();
+
+  for (const line of output.split('\n')) {
+    const match = line.match(/^\s*AllowedIPs\s*=\s*(.+)$/i);
+    if (!match) {
+      continue;
+    }
+
+    for (const value of match[1]!.split(',').map((value) => value.trim())) {
+      if (isCidr(value)) {
+        allowedIps.add(value);
+      }
+    }
+  }
+
+  return allowedIps;
+}
+
+function isDefaultRoute(cidr: string) {
+  return parseCidr(cidr).prefix === '0';
+}
+
+function routeFamily(cidr: string) {
+  return cidr.includes(':') ? '-6' : '-4';
+}
+
+async function syncRoutes(
+  infName: string,
+  routingTable: string,
+  previousAllowedIps: Set<string>,
+  desiredAllowedIps: Set<string>
+) {
+  if (routingTable === 'off') {
+    return;
+  }
+
+  const table = routingTable === 'auto' ? '' : ` table ${routingTable}`;
+
+  for (const cidr of previousAllowedIps.difference(desiredAllowedIps)) {
+    if (routingTable === 'auto' && isDefaultRoute(cidr)) {
+      continue;
+    }
+
+    await exec(
+      `ip ${routeFamily(cidr)} route delete ${cidr} dev ${infName}${table} 2>/dev/null || true`
+    );
+  }
+
+  for (const cidr of desiredAllowedIps) {
+    if (routingTable === 'auto' && isDefaultRoute(cidr)) {
+      continue;
+    }
+
+    if (routingTable !== 'auto') {
+      await exec(
+        `ip ${routeFamily(cidr)} route replace ${cidr} dev ${infName}${table}`
+      );
+      continue;
+    }
+
+    const existingRoute = await exec(
+      `ip ${routeFamily(cidr)} route show dev ${infName} match ${cidr}`
+    );
+    if (!existingRoute) {
+      await exec(`ip ${routeFamily(cidr)} route add ${cidr} dev ${infName}`);
+    }
+  }
+}
 
 export const wg = {
   generateServerPeer: (
@@ -199,9 +289,34 @@ Endpoint = ${userConfig.host}:${userConfig.port}`;
     );
   },
 
-  sync: (infName: string) => {
-    return exec(
+  sync: async (infName: string, routingTable: string) => {
+    const previousAllowedIps = parseRunningAllowedIps(
+      await exec(`${wgExecutable} show ${infName} allowed-ips`)
+    );
+    const desiredAllowedIps = parseConfigAllowedIps(
+      await exec(`${wgExecutable}-quick strip ${infName}`)
+    );
+
+    const defaultRouteChanged = [
+      ...previousAllowedIps.symmetricDifference(desiredAllowedIps),
+    ].some((cidr) => isDefaultRoute(cidr));
+
+    // wg-quick installs policy-routing rules for default routes. Recreate the
+    // interface when one changes so those rules stay in sync as well.
+    if (routingTable === 'auto' && defaultRouteChanged) {
+      return exec(
+        `${wgExecutable}-quick down ${infName}; ${wgExecutable}-quick up ${infName}`
+      );
+    }
+
+    await exec(
       `${wgExecutable} syncconf ${infName} <(${wgExecutable}-quick strip ${infName})`
+    );
+    await syncRoutes(
+      infName,
+      routingTable,
+      previousAllowedIps,
+      desiredAllowedIps
     );
   },
 

--- a/src/test/unit/wgHelper.spec.ts
+++ b/src/test/unit/wgHelper.spec.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { exec } from '#server/utils/cmd';
+import { wg } from '#server/utils/wgHelper';
+
+vi.mock('#server/utils/cmd', () => ({
+  exec: vi.fn().mockResolvedValue(''),
+}));
+
+vi.mock('#server/utils/config', () => ({
+  WG_ENV: { WG_EXECUTABLE: 'wg' },
+}));
+
+const execMock = vi.mocked(exec);
+
+describe('wg.sync', () => {
+  beforeEach(() => {
+    execMock.mockReset();
+    execMock.mockResolvedValue('');
+  });
+
+  test('adds missing routes for Server Allowed IPs', async () => {
+    execMock.mockImplementation(async (command) => {
+      if (command === 'wg show wg0 allowed-ips') {
+        return 'public-key\t10.8.0.2/32 192.168.120.0/22';
+      }
+      if (command === 'wg-quick strip wg0') {
+        return '# Client: do not route 203.0.113.0/24\n[Peer]\nAllowedIPs = 10.8.0.2/32, 192.168.120.0/22';
+      }
+      if (command.includes('match 10.8.0.2/32')) {
+        return '10.8.0.0/24 dev wg0 proto kernel';
+      }
+      return '';
+    });
+
+    await wg.sync('wg0', 'auto');
+
+    expect(execMock).toHaveBeenCalledWith(
+      'wg syncconf wg0 <(wg-quick strip wg0)'
+    );
+    expect(execMock).toHaveBeenCalledWith(
+      'ip -4 route add 192.168.120.0/22 dev wg0'
+    );
+    expect(execMock).not.toHaveBeenCalledWith(
+      'ip -4 route add 10.8.0.2/32 dev wg0'
+    );
+    expect(execMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('203.0.113.0/24')
+    );
+  });
+
+  test('removes routes no longer present in Server Allowed IPs', async () => {
+    execMock.mockImplementation(async (command) => {
+      if (command === 'wg show wg0 allowed-ips') {
+        return 'public-key\t10.8.0.2/32 192.168.120.0/22';
+      }
+      if (command === 'wg-quick strip wg0') {
+        return '[Peer]\nAllowedIPs = 10.8.0.2/32';
+      }
+      if (command.includes('match 10.8.0.2/32')) {
+        return '10.8.0.0/24 dev wg0 proto kernel';
+      }
+      return '';
+    });
+
+    await wg.sync('wg0', 'auto');
+
+    expect(execMock).toHaveBeenCalledWith(
+      'ip -4 route delete 192.168.120.0/22 dev wg0 2>/dev/null || true'
+    );
+  });
+
+  test('uses the configured routing table', async () => {
+    execMock.mockImplementation(async (command) => {
+      if (command === 'wg show wg0 allowed-ips') {
+        return 'public-key\t10.8.0.2/32';
+      }
+      if (command === 'wg-quick strip wg0') {
+        return '[Peer]\nAllowedIPs = 10.8.0.2/32, 2001:db8:1::/64';
+      }
+      return '';
+    });
+
+    await wg.sync('wg0', '123');
+
+    expect(execMock).toHaveBeenCalledWith(
+      'ip -4 route replace 10.8.0.2/32 dev wg0 table 123'
+    );
+    expect(execMock).toHaveBeenCalledWith(
+      'ip -6 route replace 2001:db8:1::/64 dev wg0 table 123'
+    );
+  });
+
+  test('does not create routes when routing is disabled', async () => {
+    execMock.mockImplementation(async (command) => {
+      if (command === 'wg show wg0 allowed-ips') {
+        return 'public-key\t10.8.0.2/32';
+      }
+      if (command === 'wg-quick strip wg0') {
+        return '[Peer]\nAllowedIPs = 10.8.0.2/32, 192.168.120.0/22';
+      }
+      return '';
+    });
+
+    await wg.sync('wg0', 'off');
+
+    expect(execMock).toHaveBeenCalledWith(
+      'wg syncconf wg0 <(wg-quick strip wg0)'
+    );
+    expect(execMock).not.toHaveBeenCalledWith(expect.stringMatching(/^ip /));
+  });
+
+  test('restarts wg-quick when its policy-routed default changes', async () => {
+    execMock.mockImplementation(async (command) => {
+      if (command === 'wg show wg0 allowed-ips') {
+        return 'public-key\t10.8.0.2/32';
+      }
+      if (command === 'wg-quick strip wg0') {
+        return '[Peer]\nAllowedIPs = 10.8.0.2/32, 0.0.0.0/0';
+      }
+      return '';
+    });
+
+    await wg.sync('wg0', 'auto');
+
+    expect(execMock).toHaveBeenCalledWith('wg-quick down wg0; wg-quick up wg0');
+    expect(execMock).not.toHaveBeenCalledWith(
+      'wg syncconf wg0 <(wg-quick strip wg0)'
+    );
+  });
+});


### PR DESCRIPTION
## Description

- Read the running and desired WireGuard AllowedIPs before synchronizing configuration.
- Reconcile missing and stale kernel routes after sync for automatic and custom routing tables.
- Leave route management disabled when the interface table is set to off.
- Recreate the interface when a default route changes because wg-quick manages additional policy-routing rules for that case.
- Parse only WireGuard AllowedIPs output so comments containing CIDR-looking text cannot create routes.

## Motivation and Context

Closes #2171.

Updating Server Allowed IPs changed WireGuard cryptokey routing, but syncconf did not update the container's kernel route table. The configured network therefore remained unreachable until an administrator added the route manually or restarted the interface.

## How has this been tested?

- Unit tests covering missing-route repair, stale-route removal, IPv4 and IPv6 custom tables, disabled routing, default-route changes, and CIDR-looking comments.
- pnpm test:unit (48 tests passed)
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm build

A live multi-site WireGuard environment was not available, so kernel route behavior is covered with mocked command-level unit tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (change which does not alter existing functionality)
- [ ] Documentation (changes to documentation only)

## Checklist

- [x] I have reviewed my own changes.
- [x] My code follows the code style of this project.
- [x] I have added or updated tests where appropriate.
- [x] My changes do not include unrelated modifications.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Documentation changes are not required because this restores the behavior already described by the Server Allowed IPs field.

## AI Disclosure

OpenAI Codex was used to investigate the issue, implement the fix and tests, run the automated checks, and draft this pull request. The changes were reviewed against wg-quick's route-management behavior. No live WireGuard integration environment was available.
